### PR TITLE
Switch to optional schema fields since we can have null values.

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -362,9 +362,9 @@ public class CliTest extends TestRunner {
             new Double[]{1100.0, 1110.99, 970.0 })));
 
     Schema resultSchema = SchemaBuilder.struct()
-        .field("ITEMID", SchemaBuilder.STRING_SCHEMA)
-        .field("ORDERUNITS", SchemaBuilder.FLOAT64_SCHEMA)
-        .field("PRICEARRAY", SchemaBuilder.array(SchemaBuilder.FLOAT64_SCHEMA))
+        .field("ITEMID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("ORDERUNITS", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
+        .field("PRICEARRAY", SchemaBuilder.array(SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .build();
 
     testCreateStreamAsSelect(

--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -47,17 +47,17 @@ public class SchemaUtil {
 
   private static Map<Pair<Schema.Type, Schema.Type>, Schema> numericTypePairMapping =
       ImmutableMap.<Pair<Schema.Type, Schema.Type>, Schema>builder()
-          .put(new Pair<>(Schema.Type.INT64, Schema.Type.INT64), Schema.INT64_SCHEMA)
-          .put(new Pair<>(Schema.Type.INT32, Schema.Type.INT64), Schema.INT64_SCHEMA)
-          .put(new Pair<>(Schema.Type.INT64, Schema.Type.INT32), Schema.INT64_SCHEMA)
-          .put(new Pair<>(Schema.Type.INT32, Schema.Type.INT32), Schema.INT32_SCHEMA)
-          .put(new Pair<>(Schema.Type.FLOAT64, Schema.Type.FLOAT64), Schema.FLOAT64_SCHEMA)
-          .put(new Pair<>(Schema.Type.FLOAT64, Schema.Type.INT32), Schema.FLOAT64_SCHEMA)
-          .put(new Pair<>(Schema.Type.INT32, Schema.Type.FLOAT64), Schema.FLOAT64_SCHEMA)
-          .put(new Pair<>(Schema.Type.FLOAT64, Schema.Type.INT64), Schema.FLOAT64_SCHEMA)
-          .put(new Pair<>(Schema.Type.INT64, Schema.Type.FLOAT64), Schema.FLOAT64_SCHEMA)
-          .put(new Pair<>(Schema.Type.FLOAT32, Schema.Type.FLOAT64), Schema.FLOAT64_SCHEMA)
-          .put(new Pair<>(Schema.Type.FLOAT64, Schema.Type.FLOAT32), Schema.FLOAT64_SCHEMA)
+          .put(new Pair<>(Schema.Type.INT64, Schema.Type.INT64), Schema.OPTIONAL_INT64_SCHEMA)
+          .put(new Pair<>(Schema.Type.INT32, Schema.Type.INT64), Schema.OPTIONAL_INT64_SCHEMA)
+          .put(new Pair<>(Schema.Type.INT64, Schema.Type.INT32), Schema.OPTIONAL_INT64_SCHEMA)
+          .put(new Pair<>(Schema.Type.INT32, Schema.Type.INT32), Schema.OPTIONAL_INT32_SCHEMA)
+          .put(new Pair<>(Schema.Type.FLOAT64, Schema.Type.FLOAT64), Schema.OPTIONAL_FLOAT64_SCHEMA)
+          .put(new Pair<>(Schema.Type.FLOAT64, Schema.Type.INT32), Schema.OPTIONAL_FLOAT64_SCHEMA)
+          .put(new Pair<>(Schema.Type.INT32, Schema.Type.FLOAT64), Schema.OPTIONAL_FLOAT64_SCHEMA)
+          .put(new Pair<>(Schema.Type.FLOAT64, Schema.Type.INT64), Schema.OPTIONAL_FLOAT64_SCHEMA)
+          .put(new Pair<>(Schema.Type.INT64, Schema.Type.FLOAT64), Schema.OPTIONAL_FLOAT64_SCHEMA)
+          .put(new Pair<>(Schema.Type.FLOAT32, Schema.Type.FLOAT64), Schema.OPTIONAL_FLOAT64_SCHEMA)
+          .put(new Pair<>(Schema.Type.FLOAT64, Schema.Type.FLOAT32), Schema.OPTIONAL_FLOAT64_SCHEMA)
           .build();
 
   public static Class getJavaType(final Schema schema) {
@@ -100,18 +100,18 @@ public class SchemaUtil {
     switch (sqlType) {
       case "VARCHAR":
       case "STRING":
-        return Schema.STRING_SCHEMA;
+        return Schema.OPTIONAL_STRING_SCHEMA;
       case "BOOLEAN":
       case "BOOL":
-        return Schema.BOOLEAN_SCHEMA;
+        return Schema.OPTIONAL_BOOLEAN_SCHEMA;
       case "INTEGER":
       case "INT":
-        return Schema.INT32_SCHEMA;
+        return Schema.OPTIONAL_INT32_SCHEMA;
       case "BIGINT":
       case "LONG":
-        return Schema.INT64_SCHEMA;
+        return Schema.OPTIONAL_INT64_SCHEMA;
       case "DOUBLE":
-        return Schema.FLOAT64_SCHEMA;
+        return Schema.OPTIONAL_FLOAT64_SCHEMA;
       default:
         return getKsqlComplexType(sqlType);
     }
@@ -189,6 +189,7 @@ public class SchemaUtil {
           .put("BOOLEAN", "BOOLEAN")
           .put("ARRAY", "ARRAY")
           .put("MAP", "MAP")
+          .put("STRUCT", "STRUCT")
           .build();
 
   public static String getSchemaFieldType(final Field field) {

--- a/ksql-common/src/test/java/io/confluent/ksql/GenericRowTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/GenericRowTest.java
@@ -30,12 +30,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class GenericRowTest {
 
   private final Schema addressSchema = SchemaBuilder.struct()
-      .field("NUMBER",Schema.INT64_SCHEMA)
-      .field("STREET", Schema.STRING_SCHEMA)
-      .field("CITY", Schema.STRING_SCHEMA)
-      .field("STATE", Schema.STRING_SCHEMA)
-      .field("ZIPCODE", Schema.INT64_SCHEMA)
-      .build();
+      .field("NUMBER",Schema.OPTIONAL_INT64_SCHEMA)
+      .field("STREET", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("CITY", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("STATE", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("ZIPCODE", Schema.OPTIONAL_INT64_SCHEMA)
+      .optional().build();
 
   @SuppressWarnings("unchecked")
   @Test

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -39,98 +39,98 @@ public class SchemaUtilTest {
   @Before
   public void init() {
     schema = SchemaBuilder.struct()
-        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
-        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA)
-        .field("arraycol".toUpperCase(), SchemaBuilder.array(org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA))
-        .field("mapcol".toUpperCase(), SchemaBuilder.map(org.apache.kafka.connect.data.Schema.STRING_SCHEMA, org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA))
+        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA)
+        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("arraycol".toUpperCase(), SchemaBuilder.array(org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
+        .field("mapcol".toUpperCase(), SchemaBuilder.map(org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA, org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .build();
   }
 
   @Test
   public void shouldGetCorrectJavaClassForBoolean() {
-    Class booleanClazz = SchemaUtil.getJavaType(Schema.BOOLEAN_SCHEMA);
+    Class booleanClazz = SchemaUtil.getJavaType(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     assertThat(booleanClazz, equalTo(Boolean.class));
   }
 
   @Test
   public void shouldGetCorrectJavaClassForInt() {
-    Class intClazz = SchemaUtil.getJavaType(Schema.INT32_SCHEMA);
+    Class intClazz = SchemaUtil.getJavaType(Schema.OPTIONAL_INT32_SCHEMA);
     assertThat(intClazz, equalTo(Integer.class));
   }
 
   @Test
   public void shouldGetCorrectJavaClassForBigInt() {
-    Class longClazz = SchemaUtil.getJavaType(Schema.INT64_SCHEMA);
+    Class longClazz = SchemaUtil.getJavaType(Schema.OPTIONAL_INT64_SCHEMA);
     assertThat(longClazz, equalTo(Long.class));
   }
 
   @Test
   public void shouldGetCorrectJavaClassForDouble() {
-    Class doubleClazz = SchemaUtil.getJavaType(Schema.FLOAT64_SCHEMA);
+    Class doubleClazz = SchemaUtil.getJavaType(Schema.OPTIONAL_FLOAT64_SCHEMA);
     assertThat(doubleClazz, equalTo(Double.class));
   }
 
   @Test
   public void shouldGetCorrectJavaClassForString() {
-    Class StringClazz = SchemaUtil.getJavaType(Schema.STRING_SCHEMA);
+    Class StringClazz = SchemaUtil.getJavaType(Schema.OPTIONAL_STRING_SCHEMA);
     assertThat(StringClazz, equalTo(String.class));
   }
 
   @Test
   public void shouldGetCorrectJavaClassForArray() {
-    Class arrayClazz = SchemaUtil.getJavaType(SchemaBuilder.array(Schema.FLOAT64_SCHEMA));
+    Class arrayClazz = SchemaUtil.getJavaType(SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build());
     assertThat(arrayClazz, equalTo(List.class));
   }
 
   @Test
   public void shouldGetCorrectJavaClassForMap() {
-    Class mapClazz = SchemaUtil.getJavaType(SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA));
+    Class mapClazz = SchemaUtil.getJavaType(SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build());
     assertThat(mapClazz, equalTo(Map.class));
   }
 
 
   @Test
   public void shouldGetCorrectSqlTypeNameForBoolean() {
-    assertThat(SchemaUtil.getSqlTypeName(Schema.BOOLEAN_SCHEMA), equalTo("BOOLEAN"));
+    assertThat(SchemaUtil.getSqlTypeName(Schema.OPTIONAL_BOOLEAN_SCHEMA), equalTo("BOOLEAN"));
   }
 
   @Test
   public void shouldGetCorrectSqlTypeNameForInt() {
-    assertThat(SchemaUtil.getSqlTypeName(Schema.INT32_SCHEMA), equalTo("INT"));
+    assertThat(SchemaUtil.getSqlTypeName(Schema.OPTIONAL_INT32_SCHEMA), equalTo("INT"));
   }
 
   @Test
   public void shouldGetCorrectSqlTypeNameForBigint() {
-    assertThat(SchemaUtil.getSqlTypeName(Schema.INT64_SCHEMA), equalTo("BIGINT"));
+    assertThat(SchemaUtil.getSqlTypeName(Schema.OPTIONAL_INT64_SCHEMA), equalTo("BIGINT"));
   }
 
   @Test
   public void shouldGetCorrectSqlTypeNameForDouble() {
-    assertThat(SchemaUtil.getSqlTypeName(Schema.FLOAT64_SCHEMA), equalTo("DOUBLE"));
+    assertThat(SchemaUtil.getSqlTypeName(Schema.OPTIONAL_FLOAT64_SCHEMA), equalTo("DOUBLE"));
   }
 
   @Test
   public void shouldGetCorrectSqlTypeNameForArray() {
-    assertThat(SchemaUtil.getSqlTypeName(SchemaBuilder.array(Schema.FLOAT64_SCHEMA)),
+    assertThat(SchemaUtil.getSqlTypeName(SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build()),
         equalTo("ARRAY<DOUBLE>"));
   }
 
   @Test
   public void shouldGetCorrectSqlTypeNameForMap() {
-    assertThat(SchemaUtil.getSqlTypeName(SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA)),
+    assertThat(SchemaUtil.getSqlTypeName(SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build()),
         equalTo("MAP<VARCHAR,DOUBLE>"));
   }
 
   @Test
   public void shouldGetCorrectSqlTypeNameForStruct() {
     Schema structSchema = SchemaBuilder.struct()
-        .field("COL1", Schema.STRING_SCHEMA)
-        .field("COL2", Schema.INT32_SCHEMA)
-        .field("COL3", Schema.FLOAT64_SCHEMA)
-        .field("COL4", SchemaBuilder.array(Schema.FLOAT64_SCHEMA))
-        .field("COL5", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA))
+        .field("COL1", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("COL2", Schema.OPTIONAL_INT32_SCHEMA)
+        .field("COL3", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("COL4", SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
+        .field("COL5", SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .build();
     assertThat(SchemaUtil.getSqlTypeName(structSchema),
         equalTo("STRUCT <COL1 VARCHAR, COL2 INT, COL3 DOUBLE, COL4 ARRAY<DOUBLE>, COL5 MAP<VARCHAR,DOUBLE>>"));
@@ -141,12 +141,12 @@ public class SchemaUtilTest {
   public void shouldCreateCorrectAvroSchemaWithNullableFields() {
     SchemaBuilder schemaBuilder = SchemaBuilder.struct();
     schemaBuilder
-        .field("ordertime", Schema.INT64_SCHEMA)
-        .field("orderid", Schema.STRING_SCHEMA)
-        .field("itemid", Schema.STRING_SCHEMA)
-        .field("orderunits", Schema.FLOAT64_SCHEMA)
-        .field("arraycol", SchemaBuilder.array(Schema.FLOAT64_SCHEMA))
-        .field("mapcol", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA));
+        .field("ordertime", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("orderid", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("itemid", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("orderunits", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("arraycol", SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
+        .field("mapcol", SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA)).optional().build();
     String avroSchemaString = SchemaUtil.buildAvroSchema(schemaBuilder.build(), "orders");
     assertThat(avroSchemaString, equalTo(
         "{\"type\":\"record\",\"name\":\"orders\",\"namespace\":\"ksql\",\"fields\":"
@@ -161,49 +161,49 @@ public class SchemaUtilTest {
 
   @Test
   public void shouldGetTheCorrectJavaTypeForBoolean() {
-    Schema schema = Schema.BOOLEAN_SCHEMA;
+    Schema schema = Schema.OPTIONAL_BOOLEAN_SCHEMA;
     Class javaClass = SchemaUtil.getJavaType(schema);
     assertThat(javaClass, equalTo(Boolean.class));
   }
 
   @Test
   public void shouldGetTheCorrectJavaTypeForInt() {
-    Schema schema = Schema.INT32_SCHEMA;
+    Schema schema = Schema.OPTIONAL_INT32_SCHEMA;
     Class javaClass = SchemaUtil.getJavaType(schema);
     assertThat(javaClass, equalTo(Integer.class));
   }
 
   @Test
   public void shouldGetTheCorrectJavaTypeForLong() {
-    Schema schema = Schema.INT64_SCHEMA;
+    Schema schema = Schema.OPTIONAL_INT64_SCHEMA;
     Class javaClass = SchemaUtil.getJavaType(schema);
     assertThat(javaClass, equalTo(Long.class));
   }
 
   @Test
   public void shouldGetTheCorrectJavaTypeForDouble() {
-    Schema schema = Schema.FLOAT64_SCHEMA;
+    Schema schema = Schema.OPTIONAL_FLOAT64_SCHEMA;
     Class javaClass = SchemaUtil.getJavaType(schema);
     assertThat(javaClass, equalTo(Double.class));
   }
 
   @Test
   public void shouldGetTheCorrectJavaTypeForString() {
-    Schema schema = Schema.STRING_SCHEMA;
+    Schema schema = Schema.OPTIONAL_STRING_SCHEMA;
     Class javaClass = SchemaUtil.getJavaType(schema);
     assertThat(javaClass, equalTo(String.class));
   }
 
   @Test
   public void shouldGetTheCorrectJavaTypeForArray() {
-    Schema schema = SchemaBuilder.array(Schema.FLOAT64_SCHEMA);
+    Schema schema = SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build();
     Class javaClass = SchemaUtil.getJavaType(schema);
     assertThat(javaClass, equalTo(List.class));
   }
 
   @Test
   public void shouldGetTheCorrectJavaTypeForMap() {
-    Schema schema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA);
+    Schema schema = SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build();
     Class javaClass = SchemaUtil.getJavaType(schema);
     assertThat(javaClass, equalTo(Map.class));
   }
@@ -224,7 +224,7 @@ public class SchemaUtilTest {
   public void shouldGetTheCorrectFieldName() {
     Optional<Field> field = SchemaUtil.getFieldByName(schema, "orderid".toUpperCase());
     Assert.assertTrue(field.isPresent());
-    assertThat(field.get().schema(), sameInstance(Schema.INT64_SCHEMA));
+    assertThat(field.get().schema(), sameInstance(Schema.OPTIONAL_INT64_SCHEMA));
     assertThat("", field.get().name().toLowerCase(), equalTo("orderid"));
 
     Optional<Field> field1 = SchemaUtil.getFieldByName(schema, "orderid");
@@ -234,31 +234,31 @@ public class SchemaUtilTest {
   @Test
   public void shouldGetTheCorrectSchemaForBoolean() {
     Schema schema = SchemaUtil.getTypeSchema("BOOLEAN");
-    assertThat(schema,  sameInstance(Schema.BOOLEAN_SCHEMA));
+    assertThat(schema,  sameInstance(Schema.OPTIONAL_BOOLEAN_SCHEMA));
   }
 
   @Test
   public void shouldGetTheCorrectSchemaForInt() {
     Schema schema = SchemaUtil.getTypeSchema("INT");
-    assertThat(schema, sameInstance(Schema.INT32_SCHEMA));
+    assertThat(schema, sameInstance(Schema.OPTIONAL_INT32_SCHEMA));
   }
 
   @Test
   public void shouldGetTheCorrectSchemaForLong() {
     Schema schema = SchemaUtil.getTypeSchema("BIGINT");
-    assertThat(schema, sameInstance(Schema.INT64_SCHEMA));
+    assertThat(schema, sameInstance(Schema.OPTIONAL_INT64_SCHEMA));
   }
 
   @Test
   public void shouldGetTheCorrectSchemaForDouble() {
     Schema schema = SchemaUtil.getTypeSchema("DOUBLE");
-    assertThat(schema, sameInstance(Schema.FLOAT64_SCHEMA));
+    assertThat(schema, sameInstance(Schema.OPTIONAL_FLOAT64_SCHEMA));
   }
 
   @Test
   public void shouldGetTheCorrectSchemaForString() {
     Schema schema = SchemaUtil.getTypeSchema("VARCHAR");
-    assertThat(schema, sameInstance(Schema.STRING_SCHEMA));
+    assertThat(schema, sameInstance(Schema.OPTIONAL_STRING_SCHEMA));
   }
 
   @Test
@@ -325,11 +325,11 @@ public class SchemaUtilTest {
 
   @Test
   public void shouldGetTheCorrectJavaCastClass() {
-    assertThat("Incorrect class.", SchemaUtil.getJavaCastString(Schema.BOOLEAN_SCHEMA), equalTo("(Boolean)"));
-    assertThat("Incorrect class.", SchemaUtil.getJavaCastString(Schema.INT32_SCHEMA), equalTo("(Integer)"));
-    assertThat("Incorrect class.", SchemaUtil.getJavaCastString(Schema.INT64_SCHEMA), equalTo("(Long)"));
-    assertThat("Incorrect class.", SchemaUtil.getJavaCastString(Schema.FLOAT64_SCHEMA), equalTo("(Double)"));
-    assertThat("Incorrect class.", SchemaUtil.getJavaCastString(Schema.STRING_SCHEMA), equalTo("(String)"));
+    assertThat("Incorrect class.", SchemaUtil.getJavaCastString(Schema.OPTIONAL_BOOLEAN_SCHEMA), equalTo("(Boolean)"));
+    assertThat("Incorrect class.", SchemaUtil.getJavaCastString(Schema.OPTIONAL_INT32_SCHEMA), equalTo("(Integer)"));
+    assertThat("Incorrect class.", SchemaUtil.getJavaCastString(Schema.OPTIONAL_INT64_SCHEMA), equalTo("(Long)"));
+    assertThat("Incorrect class.", SchemaUtil.getJavaCastString(Schema.OPTIONAL_FLOAT64_SCHEMA), equalTo("(Double)"));
+    assertThat("Incorrect class.", SchemaUtil.getJavaCastString(Schema.OPTIONAL_STRING_SCHEMA), equalTo("(String)"));
   }
 
   @Test
@@ -359,13 +359,13 @@ public class SchemaUtilTest {
 
   @Test
   public void shouldGetCorrectSqlType() {
-    String sqlType1 = SchemaUtil.getSqlTypeName(Schema.BOOLEAN_SCHEMA);
-    String sqlType2 = SchemaUtil.getSqlTypeName(Schema.INT32_SCHEMA);
-    String sqlType3 = SchemaUtil.getSqlTypeName(Schema.INT64_SCHEMA);
-    String sqlType4 = SchemaUtil.getSqlTypeName(Schema.FLOAT64_SCHEMA);
-    String sqlType5 = SchemaUtil.getSqlTypeName(Schema.STRING_SCHEMA);
-    String sqlType6 = SchemaUtil.getSqlTypeName(SchemaBuilder.array(Schema.FLOAT64_SCHEMA));
-    String sqlType7 = SchemaUtil.getSqlTypeName(SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA));
+    String sqlType1 = SchemaUtil.getSqlTypeName(Schema.OPTIONAL_BOOLEAN_SCHEMA);
+    String sqlType2 = SchemaUtil.getSqlTypeName(Schema.OPTIONAL_INT32_SCHEMA);
+    String sqlType3 = SchemaUtil.getSqlTypeName(Schema.OPTIONAL_INT64_SCHEMA);
+    String sqlType4 = SchemaUtil.getSqlTypeName(Schema.OPTIONAL_FLOAT64_SCHEMA);
+    String sqlType5 = SchemaUtil.getSqlTypeName(Schema.OPTIONAL_STRING_SCHEMA);
+    String sqlType6 = SchemaUtil.getSqlTypeName(SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build());
+    String sqlType7 = SchemaUtil.getSqlTypeName(SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build());
 
     assertThat("Invalid SQL type.", sqlType1, equalTo("BOOLEAN"));
     assertThat("Invalid SQL type.", sqlType2, equalTo("INT"));
@@ -392,22 +392,22 @@ public class SchemaUtilTest {
   @Test
   public void shouldCreateCorrectSchemaDescription() {
     Schema addressSchema = SchemaBuilder.struct()
-        .field("NUMBER", Schema.INT64_SCHEMA)
-        .field("STREET", Schema.STRING_SCHEMA)
-        .field("CITY", Schema.STRING_SCHEMA)
-        .field("STATE", Schema.STRING_SCHEMA)
-        .field("ZIPCODE", Schema.INT64_SCHEMA)
+        .field("NUMBER", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("STREET", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("CITY", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("STATE", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("ZIPCODE", Schema.OPTIONAL_INT64_SCHEMA)
         .build();
 
     SchemaBuilder schemaBuilder = SchemaBuilder.struct();
     Schema structSchema = schemaBuilder
-        .field("ordertime", Schema.INT64_SCHEMA)
-        .field("orderid", Schema.INT64_SCHEMA)
-        .field("itemid", Schema.STRING_SCHEMA)
-        .field("orderunits", Schema.FLOAT64_SCHEMA)
-        .field("arraycol",schemaBuilder.array(Schema.FLOAT64_SCHEMA))
-        .field("mapcol", schemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA))
-        .field("address", addressSchema).build();
+        .field("ordertime", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("orderid", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("itemid", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("orderunits", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("arraycol",schemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
+        .field("mapcol", schemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
+        .field("address", addressSchema).optional().build();
 
     String schemaDescription = SchemaUtil.describeSchema(structSchema);
 

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactoryTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactoryTest.java
@@ -31,7 +31,7 @@ public class TimestampExtractionPolicyFactoryTest {
 
 
   private final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-      .field("id", Schema.INT64_SCHEMA);
+      .field("id", Schema.OPTIONAL_INT64_SCHEMA);
 
   @Test
   public void shouldCreateMetadataPolicyWhenTimestampFieldNotProvided() {
@@ -43,7 +43,7 @@ public class TimestampExtractionPolicyFactoryTest {
   public void shouldCreateLongTimestampPolicyWhenTimestampFieldIsOfTypeLong() {
     final String timestamp = "timestamp";
     final Schema schema = schemaBuilder
-        .field(timestamp.toUpperCase(), Schema.INT64_SCHEMA)
+        .field(timestamp.toUpperCase(), Schema.OPTIONAL_INT64_SCHEMA)
         .build();
     TimestampExtractionPolicy extractionPolicy
         = TimestampExtractionPolicyFactory.create(schema, timestamp, null);
@@ -60,7 +60,7 @@ public class TimestampExtractionPolicyFactoryTest {
   public void shouldCreateStringTimestampPolicyWhenTimestampFieldIsStringTypeAndFormatProvided() {
     final String field = "my_string_field";
     final Schema schema = schemaBuilder
-        .field(field.toUpperCase(), Schema.STRING_SCHEMA)
+        .field(field.toUpperCase(), Schema.OPTIONAL_STRING_SCHEMA)
         .build();
     TimestampExtractionPolicy extractionPolicy
         = TimestampExtractionPolicyFactory.create(schema, field, "yyyy-MM-DD");
@@ -72,7 +72,7 @@ public class TimestampExtractionPolicyFactoryTest {
   public void shouldFailIfStringTimestampTypeAndFormatNotSupplied() {
     final String field = "my_string_field";
     final Schema schema = schemaBuilder
-        .field(field.toUpperCase(), Schema.STRING_SCHEMA)
+        .field(field.toUpperCase(), Schema.OPTIONAL_STRING_SCHEMA)
         .build();
 
     TimestampExtractionPolicyFactory.create(schema, field, null);
@@ -82,7 +82,7 @@ public class TimestampExtractionPolicyFactoryTest {
   public void shouldSupportFieldsWithQuotedStrings() {
     final String field = "my_string_field";
     final Schema schema = schemaBuilder
-        .field(field.toUpperCase(), Schema.STRING_SCHEMA)
+        .field(field.toUpperCase(), Schema.OPTIONAL_STRING_SCHEMA)
         .build();
     TimestampExtractionPolicy extractionPolicy
         = TimestampExtractionPolicyFactory.create(schema, "'"+ field+ "'", "'yyyy-MM-DD'");
@@ -94,7 +94,7 @@ public class TimestampExtractionPolicyFactoryTest {
   public void shouldThrowIfTimestampFieldTypeIsNotLongOrString() {
     final String field = "blah";
     final Schema schema = schemaBuilder
-        .field(field.toUpperCase(), Schema.FLOAT64_SCHEMA)
+        .field(field.toUpperCase(), Schema.OPTIONAL_FLOAT64_SCHEMA)
         .build();
     TimestampExtractionPolicyFactory.create(schema, "'"+ field+ "'", null);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
@@ -224,7 +224,7 @@ class QueryEngine {
       if (selectItem instanceof SingleColumn) {
         SingleColumn singleColumn = (SingleColumn) selectItem;
         String fieldName = singleColumn.getAlias().get();
-        dataSource = dataSource.field(fieldName, Schema.BOOLEAN_SCHEMA);
+        dataSource = dataSource.field(fieldName, Schema.OPTIONAL_BOOLEAN_SCHEMA);
       }
     }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
@@ -120,7 +120,7 @@ public class SqlToJavaVisitor {
         final BooleanLiteral node,
         final Boolean unmangleNames
     ) {
-      return new Pair<>(String.valueOf(node.getValue()), Schema.BOOLEAN_SCHEMA);
+      return new Pair<>(String.valueOf(node.getValue()), Schema.OPTIONAL_BOOLEAN_SCHEMA);
     }
 
     @Override
@@ -128,7 +128,7 @@ public class SqlToJavaVisitor {
         final StringLiteral node,
         final Boolean unmangleNames
     ) {
-      return new Pair<>("\"" + node.getValue() + "\"", Schema.STRING_SCHEMA);
+      return new Pair<>("\"" + node.getValue() + "\"", Schema.OPTIONAL_STRING_SCHEMA);
     }
 
     @Override
@@ -139,7 +139,7 @@ public class SqlToJavaVisitor {
 
     @Override
     protected Pair<String, Schema> visitDoubleLiteral(DoubleLiteral node, Boolean unmangleNames) {
-      return new Pair<>(Double.toString(node.getValue()), Schema.FLOAT64_SCHEMA);
+      return new Pair<>(Double.toString(node.getValue()), Schema.OPTIONAL_FLOAT64_SCHEMA);
     }
 
     @Override
@@ -219,13 +219,15 @@ public class SqlToJavaVisitor {
     }
 
     protected Pair<String, Schema> visitLongLiteral(LongLiteral node, Boolean unmangleNames) {
-      return new Pair<>("Long.parseLong(\"" + node.getValue() + "\")", Schema.INT64_SCHEMA);
+      return new Pair<>("Long.parseLong(\"" + node.getValue() + "\")",
+          Schema.OPTIONAL_INT64_SCHEMA);
     }
 
     @Override
     protected Pair<String, Schema> visitIntegerLiteral(final IntegerLiteral node,
-                                                       final Boolean context) {
-      return new Pair<>("Integer.parseInt(\"" + node.getValue() + "\")", Schema.INT32_SCHEMA);
+        final Boolean context) {
+      return new Pair<>("Integer.parseInt(\"" + node.getValue() + "\")",
+          Schema.OPTIONAL_INT32_SCHEMA);
     }
 
     @Override
@@ -263,17 +265,17 @@ public class SqlToJavaVisitor {
       if (node.getType() == LogicalBinaryExpression.Type.OR) {
         return new Pair<>(
             formatBinaryExpression(" || ", node.getLeft(), node.getRight(), unmangleNames),
-            Schema.BOOLEAN_SCHEMA
+            Schema.OPTIONAL_BOOLEAN_SCHEMA
         );
       } else if (node.getType() == LogicalBinaryExpression.Type.AND) {
         return new Pair<>(
             formatBinaryExpression(" && ", node.getLeft(), node.getRight(), unmangleNames),
-            Schema.BOOLEAN_SCHEMA
+            Schema.OPTIONAL_BOOLEAN_SCHEMA
         );
       }
       throw new UnsupportedOperationException(
           format("not yet implemented: %s.visit%s", getClass().getName(),
-                 node.getClass().getSimpleName()
+              node.getClass().getSimpleName()
           )
       );
     }
@@ -281,7 +283,7 @@ public class SqlToJavaVisitor {
     @Override
     protected Pair<String, Schema> visitNotExpression(NotExpression node, Boolean unmangleNames) {
       String exprString = process(node.getValue(), unmangleNames).getLeft();
-      return new Pair<>("(!" + exprString + ")", Schema.BOOLEAN_SCHEMA);
+      return new Pair<>("(!" + exprString + ")", Schema.OPTIONAL_BOOLEAN_SCHEMA);
     }
 
     private String nullCheckPrefix(ComparisonExpression.Type type) {
@@ -365,7 +367,7 @@ public class SqlToJavaVisitor {
           break;
       }
       String expr = "(" + String.format(exprFormat, left.getLeft(), right.getLeft()) + ")";
-      return new Pair<>(expr, Schema.BOOLEAN_SCHEMA);
+      return new Pair<>(expr, Schema.OPTIONAL_BOOLEAN_SCHEMA);
     }
 
     @Override
@@ -426,7 +428,7 @@ public class SqlToJavaVisitor {
         Boolean unmangleNames
     ) {
       Pair<String, Schema> value = process(node.getValue(), unmangleNames);
-      return new Pair<>("((" + value.getLeft() + ") == null )", Schema.BOOLEAN_SCHEMA);
+      return new Pair<>("((" + value.getLeft() + ") == null )", Schema.OPTIONAL_BOOLEAN_SCHEMA);
     }
 
     @Override
@@ -435,7 +437,7 @@ public class SqlToJavaVisitor {
         Boolean unmangleNames
     ) {
       Pair<String, Schema> value = process(node.getValue(), unmangleNames);
-      return new Pair<>("((" + value.getLeft() + ") != null )", Schema.BOOLEAN_SCHEMA);
+      return new Pair<>("((" + value.getLeft() + ") != null )", Schema.OPTIONAL_BOOLEAN_SCHEMA);
     }
 
     @Override
@@ -465,7 +467,7 @@ public class SqlToJavaVisitor {
       Pair<String, Schema> right = process(node.getRight(), unmangleNames);
       return new Pair<>(
           "(" + left.getLeft() + " " + node.getType().getValue() + " " + right.getLeft() + ")",
-          Schema.FLOAT64_SCHEMA
+          Schema.OPTIONAL_FLOAT64_SCHEMA
       );
     }
 
@@ -483,14 +485,14 @@ public class SqlToJavaVisitor {
         if (paternString.endsWith("%")) {
           return new Pair<>(
               "(" + valueString + ").contains(\""
-              + paternString.substring(1, paternString.length() - 1)
-              + "\")",
-              Schema.STRING_SCHEMA
+                  + paternString.substring(1, paternString.length() - 1)
+                  + "\")",
+              Schema.OPTIONAL_STRING_SCHEMA
           );
         } else {
           return new Pair<>(
               "(" + valueString + ").endsWith(\"" + paternString.substring(1) + "\")",
-              Schema.STRING_SCHEMA
+              Schema.OPTIONAL_STRING_SCHEMA
           );
         }
       }
@@ -498,9 +500,9 @@ public class SqlToJavaVisitor {
       if (paternString.endsWith("%")) {
         return new Pair<>(
             "(" + valueString + ")"
-            + ".startsWith(\""
-            + paternString.substring(0, paternString.length() - 1) + "\")",
-            Schema.STRING_SCHEMA
+                + ".startsWith(\""
+                + paternString.substring(0, paternString.length() - 1) + "\")",
+            Schema.OPTIONAL_STRING_SCHEMA
         );
       }
 
@@ -563,7 +565,7 @@ public class SqlToJavaVisitor {
         boolean unmangleNames
     ) {
       return "(" + process(left, unmangleNames).getLeft() + " " + operator + " "
-             + process(right, unmangleNames).getLeft() + ")";
+          + process(right, unmangleNames).getLeft() + ")";
     }
 
     private String formatIdentifier(String s) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class InternalFunctionRegistry implements FunctionRegistry {
+
   private Map<String, UdfFactory> ksqlFunctionMap = new HashMap<>();
   private Map<String, AggregateFunctionFactory> aggregateFunctionMap = new HashMap<>();
 
@@ -58,8 +59,8 @@ public class InternalFunctionRegistry implements FunctionRegistry {
   }
 
   private InternalFunctionRegistry(final Map<String, UdfFactory> ksqlFunctionMap,
-                                   final Map<String, AggregateFunctionFactory>
-                                       aggregateFunctionMap) {
+      final Map<String, AggregateFunctionFactory>
+          aggregateFunctionMap) {
     this.ksqlFunctionMap = ksqlFunctionMap;
     this.aggregateFunctionMap = aggregateFunctionMap;
   }
@@ -99,7 +100,7 @@ public class InternalFunctionRegistry implements FunctionRegistry {
 
   @Override
   public KsqlAggregateFunction getAggregate(final String functionName,
-                                            final Schema argumentType) {
+      final Schema argumentType) {
     AggregateFunctionFactory aggregateFunctionFactory
         = aggregateFunctionMap.get(functionName.toUpperCase());
     if (aggregateFunctionFactory == null) {
@@ -129,77 +130,84 @@ public class InternalFunctionRegistry implements FunctionRegistry {
      * String functions                     *
      ****************************************/
 
-    KsqlFunction lcase = new KsqlFunction(Schema.STRING_SCHEMA, Arrays.asList(Schema.STRING_SCHEMA),
-                                        "LCASE", LCaseKudf.class);
+    KsqlFunction lcase = new KsqlFunction(Schema.OPTIONAL_STRING_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_STRING_SCHEMA),
+        "LCASE", LCaseKudf.class);
     addFunction(lcase);
 
-    KsqlFunction ucase = new KsqlFunction(Schema.STRING_SCHEMA, Arrays.asList(Schema.STRING_SCHEMA),
-                                        "UCASE", UCaseKudf.class);
+    KsqlFunction ucase = new KsqlFunction(Schema.OPTIONAL_STRING_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_STRING_SCHEMA),
+        "UCASE", UCaseKudf.class);
     addFunction(ucase);
 
-    KsqlFunction substring = new KsqlFunction(Schema.STRING_SCHEMA, Arrays.asList(Schema
-                                                                                  .STRING_SCHEMA,
-                                                                              Schema
-                                                                                  .INT32_SCHEMA,
-                                                                              Schema
-                                                                                  .INT32_SCHEMA),
-                                            "SUBSTRING", SubstringKudf
-                                                .class);
+    KsqlFunction substring = new KsqlFunction(Schema.OPTIONAL_STRING_SCHEMA, Arrays.asList(
+        Schema.OPTIONAL_STRING_SCHEMA,
+        Schema.OPTIONAL_INT32_SCHEMA,
+        Schema.OPTIONAL_INT32_SCHEMA),
+        "SUBSTRING", SubstringKudf
+        .class);
     addFunction(substring);
-    addFunction(new KsqlFunction(Schema.STRING_SCHEMA, Arrays.asList(Schema
-            .STRING_SCHEMA,
-        Schema
-            .INT32_SCHEMA),
+    addFunction(new KsqlFunction(Schema.OPTIONAL_STRING_SCHEMA, Arrays.asList(
+        Schema.OPTIONAL_STRING_SCHEMA,
+        Schema.OPTIONAL_INT32_SCHEMA),
         "SUBSTRING", SubstringKudf
         .class));
 
-    KsqlFunction concat = new KsqlFunction(Schema.STRING_SCHEMA, Arrays.asList(Schema.STRING_SCHEMA,
-                                                                           Schema.STRING_SCHEMA),
-                                         "CONCAT", ConcatKudf.class);
+    KsqlFunction concat = new KsqlFunction(Schema.OPTIONAL_STRING_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_STRING_SCHEMA,
+            Schema.OPTIONAL_STRING_SCHEMA),
+        "CONCAT", ConcatKudf.class);
     addFunction(concat);
 
-    KsqlFunction trim = new KsqlFunction(Schema.STRING_SCHEMA, Arrays.asList(Schema.STRING_SCHEMA),
-                                       "TRIM", TrimKudf.class);
+    KsqlFunction trim = new KsqlFunction(Schema.OPTIONAL_STRING_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_STRING_SCHEMA),
+        "TRIM", TrimKudf.class);
     addFunction(trim);
 
-    KsqlFunction ifNull = new KsqlFunction(Schema.STRING_SCHEMA, Arrays.asList(Schema.STRING_SCHEMA,
-                                                                           Schema.STRING_SCHEMA),
-                                         "IFNULL", IfNullKudf.class);
+    KsqlFunction ifNull = new KsqlFunction(Schema.OPTIONAL_STRING_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_STRING_SCHEMA,
+            Schema.OPTIONAL_STRING_SCHEMA),
+        "IFNULL", IfNullKudf.class);
     addFunction(ifNull);
 
-    KsqlFunction len = new KsqlFunction(Schema.INT32_SCHEMA, Arrays.asList(Schema.STRING_SCHEMA),
-                                      "LEN", LenKudf.class);
+    KsqlFunction len = new KsqlFunction(
+        Schema.OPTIONAL_INT32_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_STRING_SCHEMA),
+        "LEN",
+        LenKudf.class);
     addFunction(len);
 
   }
 
   private void addMathFunctions() {
-    KsqlFunction abs = new KsqlFunction(Schema.FLOAT64_SCHEMA, Arrays.asList(Schema.FLOAT64_SCHEMA),
-                                        "ABS", AbsKudf.class);
+    KsqlFunction abs = new KsqlFunction(Schema.OPTIONAL_FLOAT64_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_FLOAT64_SCHEMA),
+        "ABS", AbsKudf.class);
     addFunction(abs);
-    addFunction(new KsqlFunction(Schema.FLOAT64_SCHEMA,
-                                 Collections.singletonList(Schema.INT64_SCHEMA),
-                                 "ABS",
-                                 AbsKudf.class));
+    addFunction(new KsqlFunction(Schema.OPTIONAL_FLOAT64_SCHEMA,
+        Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA),
+        "ABS",
+        AbsKudf.class));
 
-    KsqlFunction ceil = new KsqlFunction(Schema.FLOAT64_SCHEMA,
-                                         Arrays.asList(Schema.FLOAT64_SCHEMA),
-                                         "CEIL", CeilKudf.class);
+    KsqlFunction ceil = new KsqlFunction(Schema.OPTIONAL_FLOAT64_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_FLOAT64_SCHEMA),
+        "CEIL", CeilKudf.class);
     addFunction(ceil);
 
-    KsqlFunction floor = new KsqlFunction(Schema.FLOAT64_SCHEMA,
-                                          Arrays.asList(Schema.FLOAT64_SCHEMA),
-                                          "FLOOR", FloorKudf.class);
+    KsqlFunction floor = new KsqlFunction(Schema.OPTIONAL_FLOAT64_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_FLOAT64_SCHEMA),
+        "FLOOR", FloorKudf.class);
     addFunction(floor);
 
     KsqlFunction
         round =
-        new KsqlFunction(Schema.INT64_SCHEMA, Arrays.asList(Schema.FLOAT64_SCHEMA),
-                         "ROUND", RoundKudf.class);
+        new KsqlFunction(Schema.OPTIONAL_INT64_SCHEMA,
+            Arrays.asList(Schema.OPTIONAL_FLOAT64_SCHEMA),
+            "ROUND", RoundKudf.class);
     addFunction(round);
 
-    KsqlFunction random = new KsqlFunction(Schema.FLOAT64_SCHEMA, new ArrayList<>(),
-                                           "RANDOM", RandomKudf.class);
+    KsqlFunction random = new KsqlFunction(Schema.OPTIONAL_FLOAT64_SCHEMA, new ArrayList<>(),
+        "RANDOM", RandomKudf.class);
     addFunction(random);
 
 
@@ -208,64 +216,69 @@ public class InternalFunctionRegistry implements FunctionRegistry {
 
   private void addDateTimeFunctions() {
 
-    KsqlFunction timestampToString = new KsqlFunction(Schema.STRING_SCHEMA,
-                                                      Arrays.asList(Schema.INT64_SCHEMA,
-                                                                    Schema.STRING_SCHEMA),
-                                        "TIMESTAMPTOSTRING", TimestampToString.class);
+    KsqlFunction timestampToString = new KsqlFunction(Schema.OPTIONAL_STRING_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_INT64_SCHEMA,
+            Schema.OPTIONAL_STRING_SCHEMA),
+        "TIMESTAMPTOSTRING", TimestampToString.class);
     addFunction(timestampToString);
 
-    KsqlFunction stringToTimestamp = new KsqlFunction(Schema.INT64_SCHEMA,
-                                                      Arrays.asList(Schema.STRING_SCHEMA,
-                                                                    Schema.STRING_SCHEMA),
-                                                      "STRINGTOTIMESTAMP",
-                                                      StringToTimestamp.class);
+    KsqlFunction stringToTimestamp = new KsqlFunction(Schema.OPTIONAL_INT64_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_STRING_SCHEMA,
+            Schema.OPTIONAL_STRING_SCHEMA),
+        "STRINGTOTIMESTAMP",
+        StringToTimestamp.class);
     addFunction(stringToTimestamp);
 
   }
 
   private void addGeoFunctions() {
-    KsqlFunction geoDistance = new KsqlFunction(Schema.FLOAT64_SCHEMA,
-                                                Arrays.asList(Schema.FLOAT64_SCHEMA,
-                                                              Schema.FLOAT64_SCHEMA,
-                                                              Schema.FLOAT64_SCHEMA,
-                                                              Schema.FLOAT64_SCHEMA,
-                                                              Schema.OPTIONAL_STRING_SCHEMA),
-                                                "GEO_DISTANCE", GeoDistanceKudf.class);
+    KsqlFunction geoDistance = new KsqlFunction(Schema.OPTIONAL_FLOAT64_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_FLOAT64_SCHEMA,
+            Schema.OPTIONAL_FLOAT64_SCHEMA,
+            Schema.OPTIONAL_FLOAT64_SCHEMA,
+            Schema.OPTIONAL_FLOAT64_SCHEMA,
+            Schema.OPTIONAL_STRING_SCHEMA),
+        "GEO_DISTANCE", GeoDistanceKudf.class);
     addFunction(geoDistance);
 
   }
 
   private void addJsonFunctions() {
 
-
     KsqlFunction getStringFromJson = new KsqlFunction(
-        Schema.STRING_SCHEMA, Arrays.asList(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA),
+        Schema.OPTIONAL_STRING_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA),
         "EXTRACTJSONFIELD", JsonExtractStringKudf.class);
     addFunction(getStringFromJson);
 
     KsqlFunction jsonArrayContainsString = new KsqlFunction(
-            Schema.BOOLEAN_SCHEMA, Arrays.asList(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA),
-            "ARRAYCONTAINS", ArrayContainsKudf.class);
+        Schema.OPTIONAL_BOOLEAN_SCHEMA,
+        Arrays.asList(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA),
+        "ARRAYCONTAINS", ArrayContainsKudf.class);
     addFunction(jsonArrayContainsString);
 
     addFunction(new KsqlFunction(
-        Schema.BOOLEAN_SCHEMA,
-        Arrays.asList(SchemaBuilder.array(Schema.STRING_SCHEMA).build(), Schema.STRING_SCHEMA),
+        Schema.OPTIONAL_BOOLEAN_SCHEMA,
+        Arrays.asList(SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build(),
+            Schema.OPTIONAL_STRING_SCHEMA),
         "ARRAYCONTAINS", ArrayContainsKudf.class));
 
     addFunction(new KsqlFunction(
-        Schema.BOOLEAN_SCHEMA,
-        Arrays.asList(SchemaBuilder.array(Schema.INT32_SCHEMA).build(), Schema.INT32_SCHEMA),
+        Schema.OPTIONAL_BOOLEAN_SCHEMA,
+        Arrays.asList(SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build(),
+            Schema.OPTIONAL_INT32_SCHEMA),
         "ARRAYCONTAINS", ArrayContainsKudf.class));
 
     addFunction(new KsqlFunction(
-        Schema.BOOLEAN_SCHEMA,
-        Arrays.asList(SchemaBuilder.array(Schema.INT64_SCHEMA).build(), Schema.INT64_SCHEMA),
+        Schema.OPTIONAL_BOOLEAN_SCHEMA,
+        Arrays.asList(SchemaBuilder.array(Schema.OPTIONAL_INT64_SCHEMA).optional().build(),
+            Schema.OPTIONAL_INT64_SCHEMA),
         "ARRAYCONTAINS", ArrayContainsKudf.class));
 
     addFunction(new KsqlFunction(
-        Schema.BOOLEAN_SCHEMA,
-        Arrays.asList(SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build(), Schema.FLOAT64_SCHEMA),
+        Schema.OPTIONAL_BOOLEAN_SCHEMA,
+        Arrays.asList(SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build(),
+            Schema.OPTIONAL_FLOAT64_SCHEMA),
         "ARRAYCONTAINS", ArrayContainsKudf.class));
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountKudaf.java
@@ -31,8 +31,8 @@ public class CountKudaf
     extends BaseAggregateFunction<Object, Long> implements TableAggregationFunction<Object, Long> {
 
   CountKudaf(String functionName, int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> 0L, Schema.INT64_SCHEMA,
-          Collections.singletonList(Schema.FLOAT64_SCHEMA)
+    super(functionName, argIndexInValue, () -> 0L, Schema.OPTIONAL_INT64_SCHEMA,
+          Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
@@ -28,8 +28,9 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 public class DoubleMaxKudaf extends BaseAggregateFunction<Double, Double> {
 
   DoubleMaxKudaf(String functionName, int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> Double.NEGATIVE_INFINITY, Schema.FLOAT64_SCHEMA,
-          Collections.singletonList(Schema.FLOAT64_SCHEMA)
+    super(functionName, argIndexInValue, () -> Double.NEGATIVE_INFINITY,
+        Schema.OPTIONAL_FLOAT64_SCHEMA,
+        Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudaf.java
@@ -28,8 +28,8 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 public class IntegerMaxKudaf extends BaseAggregateFunction<Integer, Integer> {
 
   IntegerMaxKudaf(String functionName, int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> Integer.MIN_VALUE, Schema.INT32_SCHEMA,
-          Collections.singletonList(Schema.INT32_SCHEMA)
+    super(functionName, argIndexInValue, () -> Integer.MIN_VALUE, Schema.OPTIONAL_INT32_SCHEMA,
+          Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
@@ -28,8 +28,8 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 public class LongMaxKudaf extends BaseAggregateFunction<Long, Long> {
 
   LongMaxKudaf(String functionName, int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> Long.MIN_VALUE, Schema.INT64_SCHEMA,
-          Collections.singletonList(Schema.INT64_SCHEMA)
+    super(functionName, argIndexInValue, () -> Long.MIN_VALUE, Schema.OPTIONAL_INT64_SCHEMA,
+          Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
@@ -28,8 +28,8 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 public class DoubleMinKudaf extends BaseAggregateFunction<Double, Double> {
 
   DoubleMinKudaf(String functionName, int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> Double.MAX_VALUE, Schema.FLOAT64_SCHEMA,
-          Collections.singletonList(Schema.FLOAT64_SCHEMA)
+    super(functionName, argIndexInValue, () -> Double.MAX_VALUE, Schema.OPTIONAL_FLOAT64_SCHEMA,
+          Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
@@ -28,8 +28,8 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 public class IntegerMinKudaf extends BaseAggregateFunction<Integer, Integer> {
 
   IntegerMinKudaf(String functionName, int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> Integer.MAX_VALUE, Schema.INT32_SCHEMA,
-          Collections.singletonList(Schema.INT32_SCHEMA)
+    super(functionName, argIndexInValue, () -> Integer.MAX_VALUE, Schema.OPTIONAL_INT32_SCHEMA,
+          Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
@@ -28,8 +28,8 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 public class LongMinKudaf extends BaseAggregateFunction<Long, Long> {
 
   LongMinKudaf(String functionName, int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> Long.MAX_VALUE, Schema.INT64_SCHEMA,
-          Collections.singletonList(Schema.INT64_SCHEMA)
+    super(functionName, argIndexInValue, () -> Long.MAX_VALUE, Schema.OPTIONAL_INT64_SCHEMA,
+          Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
@@ -31,8 +31,8 @@ public class DoubleSumKudaf
     implements TableAggregationFunction<Double, Double> {
 
   DoubleSumKudaf(String functionName, int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> 0.0, Schema.FLOAT64_SCHEMA,
-          Collections.singletonList(Schema.FLOAT64_SCHEMA)
+    super(functionName, argIndexInValue, () -> 0.0, Schema.OPTIONAL_FLOAT64_SCHEMA,
+          Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
@@ -31,8 +31,8 @@ public class IntegerSumKudaf
     implements TableAggregationFunction<Integer, Integer> {
 
   IntegerSumKudaf(String functionName, int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> 0, Schema.INT32_SCHEMA,
-          Collections.singletonList(Schema.INT32_SCHEMA)
+    super(functionName, argIndexInValue, () -> 0, Schema.OPTIONAL_INT32_SCHEMA,
+          Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
@@ -30,8 +30,8 @@ public class LongSumKudaf
     extends BaseAggregateFunction<Long, Long> implements TableAggregationFunction<Long, Long> {
 
   LongSumKudaf(String functionName, int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> 0L, Schema.INT64_SCHEMA,
-          Collections.singletonList(Schema.INT64_SCHEMA));
+    super(functionName, argIndexInValue, () -> 0L, Schema.OPTIONAL_INT64_SCHEMA,
+          Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA));
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopKAggregateFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopKAggregateFunctionFactory.java
@@ -50,32 +50,32 @@ public class TopKAggregateFunctionFactory extends AggregateFunctionFactory {
             functionName,
             -1,
             topKSize,
-            SchemaBuilder.array(Schema.INT32_SCHEMA).build(),
-            Collections.singletonList(Schema.INT32_SCHEMA),
+            SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build(),
+            Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA),
             Integer.class);
       case INT64:
         return new TopkKudaf<>(
             functionName,
             -1,
             topKSize,
-            SchemaBuilder.array(Schema.INT64_SCHEMA).build(),
-            Collections.singletonList(Schema.INT64_SCHEMA),
+            SchemaBuilder.array(Schema.OPTIONAL_INT64_SCHEMA).optional().build(),
+            Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA),
             Long.class);
       case FLOAT64:
         return new TopkKudaf<>(
             functionName,
             -1,
             topKSize,
-            SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build(),
-            Collections.singletonList(Schema.FLOAT64_SCHEMA),
+            SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build(),
+            Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
             Double.class);
       case STRING:
         return new TopkKudaf<>(
             functionName,
             -1,
             topKSize,
-            SchemaBuilder.array(Schema.STRING_SCHEMA).build(),
-            Collections.singletonList(Schema.STRING_SCHEMA),
+            SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build(),
+            Collections.singletonList(Schema.OPTIONAL_STRING_SCHEMA),
             String.class);
       default:
         throw new KsqlException("No TOPK aggregate function with " + argumentType.get(0)

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
@@ -39,13 +39,17 @@ public class TopkDistinctAggFunctionFactory extends AggregateFunctionFactory {
     Schema argSchema = argTypeList.get(0);
     switch (argSchema.type()) {
       case INT32:
-        return new TopkDistinctKudaf<>(functionName, -1, 0, Schema.INT32_SCHEMA, Integer.class);
+        return new TopkDistinctKudaf<>(functionName, -1, 0, Schema.OPTIONAL_INT32_SCHEMA,
+            Integer.class);
       case INT64:
-        return new TopkDistinctKudaf<>(functionName, -1, 0, Schema.INT64_SCHEMA, Long.class);
+        return new TopkDistinctKudaf<>(functionName, -1, 0, Schema.OPTIONAL_INT64_SCHEMA,
+            Long.class);
       case FLOAT64:
-        return new TopkDistinctKudaf<>(functionName, -1, 0, Schema.FLOAT64_SCHEMA, Double.class);
+        return new TopkDistinctKudaf<>(functionName, -1, 0, Schema.OPTIONAL_FLOAT64_SCHEMA,
+            Double.class);
       case STRING:
-        return new TopkDistinctKudaf<>(functionName, -1, 0, Schema.STRING_SCHEMA, String.class);
+        return new TopkDistinctKudaf<>(functionName, -1, 0, Schema.OPTIONAL_STRING_SCHEMA,
+            String.class);
       default:
         throw new KsqlException("No TOPKDISTINCT aggregate function with " + argTypeList.get(0)
             + " argument type exists!");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
@@ -47,7 +47,7 @@ public class TopkDistinctKudaf<T extends Comparable<? super T>>
     super(
         functionName, argIndexInValue,
         ArrayList::new,
-        SchemaBuilder.array(outputSchema).build(),
+        SchemaBuilder.array(outputSchema).optional().build(),
         Collections.singletonList(outputSchema)
     );
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -377,7 +377,7 @@ public class SchemaKStream {
     // TODO: if the key is a prefix of the grouping columns then we can
     //       use the repartition reflection hack to tell streams not to
     //       repartition.
-    Field newKeyField = new Field(aggregateKeyName, -1, Schema.STRING_SCHEMA);
+    Field newKeyField = new Field(aggregateKeyName, -1, Schema.OPTIONAL_STRING_SCHEMA);
     return new SchemaKGroupedStream(
         schema,
         kgroupedStream,

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -183,7 +183,7 @@ public class SchemaKTable extends SchemaKStream {
             new KeyValue<>(buildGroupByKey(newKeyIndexes, value), value),
         Serialized.with(keySerde, valSerde));
 
-    final Field newKeyField = new Field(aggregateKeyName, -1, Schema.STRING_SCHEMA);
+    final Field newKeyField = new Field(aggregateKeyName, -1, Schema.OPTIONAL_STRING_SCHEMA);
     return new SchemaKGroupedTable(
         schema,
         kgroupedTable,

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
@@ -99,7 +99,7 @@ public class ExpressionTypeManager
   @Override
   protected Expression visitComparisonExpression(
       final ComparisonExpression node, final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.BOOLEAN_SCHEMA);
+    expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     return null;
   }
 
@@ -129,50 +129,50 @@ public class ExpressionTypeManager
 
   protected Expression visitStringLiteral(final StringLiteral node,
                                           final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.STRING_SCHEMA);
+    expressionTypeContext.setSchema(Schema.OPTIONAL_STRING_SCHEMA);
     return null;
   }
 
   protected Expression visitBooleanLiteral(final BooleanLiteral node,
                                            final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.BOOLEAN_SCHEMA);
+    expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     return null;
   }
 
   protected Expression visitLongLiteral(final LongLiteral node,
                                         final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.INT64_SCHEMA);
+    expressionTypeContext.setSchema(Schema.OPTIONAL_INT64_SCHEMA);
     return null;
   }
 
   @Override
   protected Expression visitIntegerLiteral(final IntegerLiteral node,
                                            final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.INT32_SCHEMA);
+    expressionTypeContext.setSchema(Schema.OPTIONAL_INT32_SCHEMA);
     return null;
   }
 
   protected Expression visitDoubleLiteral(final DoubleLiteral node,
                                           final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.FLOAT64_SCHEMA);
+    expressionTypeContext.setSchema(Schema.OPTIONAL_FLOAT64_SCHEMA);
     return null;
   }
 
   protected Expression visitLikePredicate(LikePredicate node,
                                           ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.BOOLEAN_SCHEMA);
+    expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     return null;
   }
 
   protected Expression visitIsNotNullPredicate(IsNotNullPredicate node,
                                                ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.BOOLEAN_SCHEMA);
+    expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     return null;
   }
 
   protected Expression visitIsNullPredicate(IsNullPredicate node,
                                             ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.BOOLEAN_SCHEMA);
+    expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     return null;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/SerDeUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/SerDeUtil.java
@@ -30,7 +30,7 @@ public class SerDeUtil {
     org.apache.avro.Schema avroSchema = parser.parse(avroSchemaString);
 
     SchemaBuilder inferredSchema = SchemaBuilder.struct().name(avroSchema.getName());
-    for (org.apache.avro.Schema.Field avroField: avroSchema.getFields()) {
+    for (org.apache.avro.Schema.Field avroField : avroSchema.getFields()) {
       inferredSchema.field(avroField.name(), getKsqlSchemaForAvroSchema(avroField.schema()));
     }
 
@@ -40,27 +40,28 @@ public class SerDeUtil {
   private static Schema getKsqlSchemaForAvroSchema(org.apache.avro.Schema avroSchema) {
     switch (avroSchema.getType()) {
       case INT:
-        return Schema.INT32_SCHEMA;
+        return Schema.OPTIONAL_INT32_SCHEMA;
       case LONG:
-        return Schema.INT64_SCHEMA;
+        return Schema.OPTIONAL_INT64_SCHEMA;
       case DOUBLE:
       case FLOAT:
-        return Schema.FLOAT64_SCHEMA;
+        return Schema.OPTIONAL_FLOAT64_SCHEMA;
       case BOOLEAN:
-        return Schema.BOOLEAN_SCHEMA;
+        return Schema.OPTIONAL_BOOLEAN_SCHEMA;
       case STRING:
-        return Schema.STRING_SCHEMA;
+        return Schema.OPTIONAL_STRING_SCHEMA;
       case ARRAY:
-        return SchemaBuilder.array(getKsqlSchemaForAvroSchema(avroSchema.getElementType()));
+        return SchemaBuilder.array(getKsqlSchemaForAvroSchema(avroSchema.getElementType()))
+            .optional().build();
       case MAP:
-        return SchemaBuilder.map(Schema.STRING_SCHEMA,
-                                 getKsqlSchemaForAvroSchema(avroSchema.getValueType()));
+        return SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA,
+            getKsqlSchemaForAvroSchema(avroSchema.getValueType())).optional().build();
       case UNION:
         return handleUnion(avroSchema);
-        
+
       default:
         throw new KsqlException(String.format("KSQL doesn't currently support Avro type: %s",
-                                              avroSchema.getFullName()));
+            avroSchema.getFullName()));
     }
   }
 
@@ -76,7 +77,7 @@ public class SerDeUtil {
       }
     }
     throw new KsqlException("Union type cannot have more than two types and "
-                                          + "one of them should be null.");
+        + "one of them should be null.");
   }
 
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -88,39 +88,39 @@ public class CodeGenRunnerTest {
     public void init() {
         metaStore = MetaStoreFixture.getNewMetaStore(functionRegistry);
         final Schema schema = SchemaBuilder.struct()
-            .field("CODEGEN_TEST.COL0", SchemaBuilder.INT64_SCHEMA)
-            .field("CODEGEN_TEST.COL1", SchemaBuilder.STRING_SCHEMA)
-            .field("CODEGEN_TEST.COL2", SchemaBuilder.STRING_SCHEMA)
-            .field("CODEGEN_TEST.COL3", SchemaBuilder.FLOAT64_SCHEMA)
-            .field("CODEGEN_TEST.COL4", SchemaBuilder.FLOAT64_SCHEMA)
-            .field("CODEGEN_TEST.COL5", SchemaBuilder.INT32_SCHEMA)
-            .field("CODEGEN_TEST.COL6", SchemaBuilder.BOOLEAN_SCHEMA)
-            .field("CODEGEN_TEST.COL7", SchemaBuilder.BOOLEAN_SCHEMA)
-            .field("CODEGEN_TEST.COL8", SchemaBuilder.INT64_SCHEMA)
-            .field("CODEGEN_TEST.COL9", SchemaBuilder.array(SchemaBuilder.INT32_SCHEMA))
-            .field("CODEGEN_TEST.COL10", SchemaBuilder.array(SchemaBuilder.INT32_SCHEMA))
+            .field("CODEGEN_TEST.COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+            .field("CODEGEN_TEST.COL1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+            .field("CODEGEN_TEST.COL2", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+            .field("CODEGEN_TEST.COL3", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
+            .field("CODEGEN_TEST.COL4", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
+            .field("CODEGEN_TEST.COL5", SchemaBuilder.OPTIONAL_INT32_SCHEMA)
+            .field("CODEGEN_TEST.COL6", SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA)
+            .field("CODEGEN_TEST.COL7", SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA)
+            .field("CODEGEN_TEST.COL8", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+            .field("CODEGEN_TEST.COL9", SchemaBuilder.array(SchemaBuilder.OPTIONAL_INT32_SCHEMA).optional().build())
+            .field("CODEGEN_TEST.COL10", SchemaBuilder.array(SchemaBuilder.OPTIONAL_INT32_SCHEMA).optional().build())
             .field("CODEGEN_TEST.COL11",
-                   SchemaBuilder.map(SchemaBuilder.STRING_SCHEMA, SchemaBuilder.STRING_SCHEMA))
+                   SchemaBuilder.map(SchemaBuilder.OPTIONAL_STRING_SCHEMA, SchemaBuilder.OPTIONAL_STRING_SCHEMA).optional().build())
             .field("CODEGEN_TEST.COL12",
-                   SchemaBuilder.map(SchemaBuilder.STRING_SCHEMA, SchemaBuilder.INT32_SCHEMA))
-            .field("CODEGEN_TEST.COL13", SchemaBuilder.array(SchemaBuilder.STRING_SCHEMA));
+                   SchemaBuilder.map(SchemaBuilder.OPTIONAL_STRING_SCHEMA, SchemaBuilder.OPTIONAL_INT32_SCHEMA).optional().build())
+            .field("CODEGEN_TEST.COL13", SchemaBuilder.array(SchemaBuilder.OPTIONAL_STRING_SCHEMA).optional().build());
         Schema metaStoreSchema = SchemaBuilder.struct()
-            .field("COL0", SchemaBuilder.INT64_SCHEMA)
-            .field("COL1", SchemaBuilder.STRING_SCHEMA)
-            .field("COL2", SchemaBuilder.STRING_SCHEMA)
-            .field("COL3", SchemaBuilder.FLOAT64_SCHEMA)
-            .field("COL4", SchemaBuilder.FLOAT64_SCHEMA)
-            .field("COL5", SchemaBuilder.INT32_SCHEMA)
-            .field("COL6", SchemaBuilder.BOOLEAN_SCHEMA)
-            .field("COL7", SchemaBuilder.BOOLEAN_SCHEMA)
-            .field("COL8", SchemaBuilder.INT64_SCHEMA)
-            .field("COL9", SchemaBuilder.array(SchemaBuilder.INT32_SCHEMA))
-            .field("COL10", SchemaBuilder.array(SchemaBuilder.INT32_SCHEMA))
+            .field("COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+            .field("COL1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+            .field("COL2", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+            .field("COL3", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
+            .field("COL4", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
+            .field("COL5", SchemaBuilder.OPTIONAL_INT32_SCHEMA)
+            .field("COL6", SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA)
+            .field("COL7", SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA)
+            .field("COL8", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+            .field("COL9", SchemaBuilder.array(SchemaBuilder.OPTIONAL_INT32_SCHEMA).optional().build())
+            .field("COL10", SchemaBuilder.array(SchemaBuilder.OPTIONAL_INT32_SCHEMA).optional().build())
             .field("COL11",
-                SchemaBuilder.map(SchemaBuilder.STRING_SCHEMA, SchemaBuilder.STRING_SCHEMA))
+                SchemaBuilder.map(SchemaBuilder.OPTIONAL_STRING_SCHEMA, SchemaBuilder.OPTIONAL_STRING_SCHEMA).optional().build())
             .field("COL12",
-                SchemaBuilder.map(SchemaBuilder.STRING_SCHEMA, SchemaBuilder.INT32_SCHEMA))
-            .field("COL13", SchemaBuilder.array(SchemaBuilder.STRING_SCHEMA));
+                SchemaBuilder.map(SchemaBuilder.OPTIONAL_STRING_SCHEMA, SchemaBuilder.OPTIONAL_INT32_SCHEMA).optional().build())
+            .field("COL13", SchemaBuilder.array(SchemaBuilder.OPTIONAL_STRING_SCHEMA).optional().build());
         KsqlTopic ksqlTopic = new KsqlTopic(
             "CODEGEN_TEST",
             "codegen_test",

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
@@ -33,21 +33,21 @@ public class SqlToJavaVisitorTest {
     metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
     functionRegistry = new InternalFunctionRegistry();
     final Schema addressSchema = SchemaBuilder.struct()
-        .field("NUMBER",Schema.INT64_SCHEMA)
-        .field("STREET", Schema.STRING_SCHEMA)
-        .field("CITY", Schema.STRING_SCHEMA)
-        .field("STATE", Schema.STRING_SCHEMA)
-        .field("ZIPCODE", Schema.INT64_SCHEMA)
-        .build();
+        .field("NUMBER",Schema.OPTIONAL_INT64_SCHEMA)
+        .field("STREET", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("CITY", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("STATE", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("ZIPCODE", Schema.OPTIONAL_INT64_SCHEMA)
+        .optional().build();
 
 
     schema = SchemaBuilder.struct()
-        .field("TEST1.COL0", SchemaBuilder.INT64_SCHEMA)
-        .field("TEST1.COL1", SchemaBuilder.STRING_SCHEMA)
-        .field("TEST1.COL2", SchemaBuilder.STRING_SCHEMA)
-        .field("TEST1.COL3", SchemaBuilder.FLOAT64_SCHEMA)
-        .field("TEST1.COL4", SchemaBuilder.array(Schema.FLOAT64_SCHEMA))
-        .field("TEST1.COL5", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA))
+        .field("TEST1.COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+        .field("TEST1.COL1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("TEST1.COL2", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("TEST1.COL3", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
+        .field("TEST1.COL4", SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
+        .field("TEST1.COL5", SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .field("TEST1.COL6", addressSchema)
         .build();
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
@@ -52,7 +52,7 @@ public class InternalFunctionRegistryTest {
   }
 
   private final InternalFunctionRegistry functionRegistry = new InternalFunctionRegistry();
-  private final KsqlFunction func = new KsqlFunction(Schema.STRING_SCHEMA,
+  private final KsqlFunction func = new KsqlFunction(Schema.OPTIONAL_STRING_SCHEMA,
       Collections.emptyList(),
       "func",
       Func1.class);
@@ -67,7 +67,7 @@ public class InternalFunctionRegistryTest {
 
   @Test
   public void shouldNotAddFunctionWithSameNameAsExistingFunctionAndOnDifferentClass() {
-    final KsqlFunction func2 = new KsqlFunction(Schema.STRING_SCHEMA,
+    final KsqlFunction func2 = new KsqlFunction(Schema.OPTIONAL_STRING_SCHEMA,
         Collections.emptyList(),
         "func",
         Func2.class);
@@ -85,7 +85,7 @@ public class InternalFunctionRegistryTest {
   public void shouldCreateCopyOfRegistry() {
     functionRegistry.addFunction(func);
     final FunctionRegistry copy = functionRegistry.copy();
-    final KsqlFunction func2 = new KsqlFunction(Schema.STRING_SCHEMA,
+    final KsqlFunction func2 = new KsqlFunction(Schema.OPTIONAL_STRING_SCHEMA,
         Collections.emptyList(),
         "func2",
        Func2.class);
@@ -152,27 +152,27 @@ public class InternalFunctionRegistryTest {
             };
           }
         });
-    assertThat(functionRegistry.getAggregate("my_aggregate", Schema.INT32_SCHEMA), not(nullValue()));
+    assertThat(functionRegistry.getAggregate("my_aggregate", Schema.OPTIONAL_INT32_SCHEMA), not(nullValue()));
   }
 
   @Test
   public void shouldAddFunctionWithSameNameButDifferentReturnTypes() {
     functionRegistry.addFunction(func);
     assertTrue(functionRegistry.addFunction(
-        new KsqlFunction(Schema.INT64_SCHEMA,
-            Collections.singletonList(Schema.INT64_SCHEMA), "func", Func1.class)));
+        new KsqlFunction(Schema.OPTIONAL_INT64_SCHEMA,
+            Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA), "func", Func1.class)));
   }
 
   @Test
   public void shouldAddFunctionWithSameNameClassButDifferentArguments() {
-    final KsqlFunction func2 = new KsqlFunction(Schema.STRING_SCHEMA,
-        Collections.singletonList(Schema.INT64_SCHEMA), "func", Func1.class);
+    final KsqlFunction func2 = new KsqlFunction(Schema.OPTIONAL_STRING_SCHEMA,
+        Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA), "func", Func1.class);
 
     functionRegistry.addFunction(func);
     assertTrue(functionRegistry.addFunction(
         func2));
     assertThat(functionRegistry.getUdfFactory("func")
-        .getFunction(Collections.singletonList(Schema.INT64_SCHEMA.type())), equalTo(func2));
+        .getFunction(Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA.type())), equalTo(func2));
     assertThat(functionRegistry.getUdfFactory("func")
         .getFunction(Collections.emptyList()), equalTo(func));
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
@@ -48,7 +48,7 @@ public class KudafUndoAggregatorTest {
     Map<Integer, TableAggregationFunction> aggValToAggFunctionMap = new HashMap<>();
     Map<String, Integer> expressionNames = Collections.singletonMap("baz", 2);
     KsqlAggregateFunction functionInfo = functionRegistry.getAggregate(
-        "SUM", Schema.INT32_SCHEMA);
+        "SUM", Schema.OPTIONAL_INT32_SCHEMA);
     assertThat(functionInfo, instanceOf(TableAggregationFunction.class));
     aggValToAggFunctionMap.put(
         2, (TableAggregationFunction)functionInfo.getInstance(

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
@@ -56,7 +56,7 @@ public class IntegerMaxKudafTest {
 
   private IntegerMaxKudaf getIntegerMaxKudaf() {
     KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
     assertThat(aggregateFunction, instanceOf(IntegerMaxKudaf.class));
     return  (IntegerMaxKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
@@ -58,7 +58,7 @@ public class IntegerMinKudafTest {
 
   private IntegerMinKudaf getIntegerMinKudaf() {
     KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
     assertThat(aggregateFunction, instanceOf(IntegerMinKudaf.class));
     return  (IntegerMinKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudafTest.java
@@ -15,7 +15,7 @@ public class DoubleSumKudafTest extends BaseSumKudafTest<Double, DoubleSumKudaf>
 
   protected DoubleSumKudaf getSumKudaf() {
     KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.FLOAT64_SCHEMA));
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA));
     assertThat(aggregateFunction, instanceOf(DoubleSumKudaf.class));
     return  (DoubleSumKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
@@ -22,7 +22,7 @@ public class IntegerSumKudafTest extends BaseSumKudafTest<Integer, IntegerSumKud
 
   protected IntegerSumKudaf getSumKudaf() {
     KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
     assertThat(aggregateFunction, instanceOf(IntegerSumKudaf.class));
     return  (IntegerSumKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/LongSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/LongSumKudafTest.java
@@ -15,7 +15,7 @@ public class LongSumKudafTest extends BaseSumKudafTest<Long, LongSumKudaf> {
 
   protected LongSumKudaf getSumKudaf() {
     KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.INT64_SCHEMA));
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA));
     assertThat(aggregateFunction, instanceOf(LongSumKudaf.class));
     return  (LongSumKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/DoubleTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/DoubleTopkKudafTest.java
@@ -39,7 +39,7 @@ public class DoubleTopkKudafTest {
   @Before
   public void setup() {
     topKFactory = new TopKAggregateFunctionFactory(3);
-    argumentType = Collections.singletonList(Schema.FLOAT64_SCHEMA);
+    argumentType = Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA);
   }
 
   @Test
@@ -58,7 +58,7 @@ public class DoubleTopkKudafTest {
   public void shouldAggregateTopKWithLessThanKValues() {
     KsqlAggregateFunction<Object, List<Double>> topkKudaf =
         topKFactory.getProperAggregateFunction(argumentType);
-    List<Double> currentVal = new ArrayList();
+    List<Double> currentVal = new ArrayList<>();
     currentVal = topkKudaf.aggregate(10.0, currentVal);
 
     assertThat("Invalid results.", currentVal, equalTo(ImmutableList.of(10.0)));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/IntTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/IntTopkKudafTest.java
@@ -45,7 +45,7 @@ public class IntTopkKudafTest {
   @Before
   public void setup() {
     topkKudaf = new TopKAggregateFunctionFactory(3)
-        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
   }
 
   @Test
@@ -107,7 +107,7 @@ public class IntTopkKudafTest {
     // Given:
     final int topKSize = 300;
     topkKudaf = new TopKAggregateFunctionFactory(topKSize)
-        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
     final List<Integer> initialAggregate = IntStream.range(0, topKSize)
         .boxed()
         .collect(Collectors.toList());
@@ -128,7 +128,7 @@ public class IntTopkKudafTest {
   public void shouldBeThreadSafe() {
     // Given:
     topkKudaf = new TopKAggregateFunctionFactory(12)
-        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
 
     final List<Integer> values = ImmutableList.of(10, 30, 45, 10, 50, 60, 20, 70, 80, 35, 25);
 
@@ -156,7 +156,7 @@ public class IntTopkKudafTest {
     final int iterations = 1_000_000_000;
     final int topX = 10;
     topkKudaf = new TopKAggregateFunctionFactory(topX)
-        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
     final List<Integer> aggregate = new ArrayList<>();
     final long start = System.currentTimeMillis();
 
@@ -174,7 +174,7 @@ public class IntTopkKudafTest {
     final int iterations = 1_000_000_000;
     final int topX = 10;
     topkKudaf = new TopKAggregateFunctionFactory(topX)
-        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
 
     final List<Integer> aggregate1 = IntStream.range(0, topX)
         .mapToObj(v -> v % 2 == 0 ? v + 1 : v)

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/LongTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/LongTopkKudafTest.java
@@ -39,7 +39,7 @@ public class LongTopkKudafTest {
   @Before
   public void setup() {
     topKFactory = new TopKAggregateFunctionFactory(3);
-    argumentType = Collections.singletonList(Schema.INT64_SCHEMA);
+    argumentType = Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA);
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/StringTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/StringTopkKudafTest.java
@@ -41,7 +41,7 @@ public class StringTopkKudafTest {
   @Before
   public void setup() {
     topKFactory = new TopKAggregateFunctionFactory(3);
-    argumentType = Collections.singletonList(Schema.STRING_SCHEMA);
+    argumentType = Collections.singletonList(Schema.OPTIONAL_STRING_SCHEMA);
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DoubleTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DoubleTopkDistinctKudafTest.java
@@ -34,7 +34,7 @@ public class DoubleTopkDistinctKudafTest {
   private final List<Double> valuesArray = ImmutableList.of(10.0, 30.0, 45.0, 10.0, 50.0, 60.0, 20.0, 60.0,
       80.0, 35.0, 25.0, 60.0, 80.0);;
   private final TopkDistinctKudaf<Double> doubleTopkDistinctKudaf
-      = TopKDistinctTestUtils.getTopKDistinctKudaf(3, Schema.FLOAT64_SCHEMA);
+      = TopKDistinctTestUtils.getTopKDistinctKudaf(3, Schema.OPTIONAL_FLOAT64_SCHEMA);
 
   @Test
   public void shouldAggregateTopK() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/IntTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/IntTopkDistinctKudafTest.java
@@ -38,7 +38,7 @@ public class IntTopkDistinctKudafTest {
   private final List<Integer> valuesArray =
       ImmutableList.of(10, 30, 45, 10, 50, 60, 20, 60, 80, 35, 25, 60, 80);
   private final TopkDistinctKudaf<Integer> intTopkDistinctKudaf =
-      TopKDistinctTestUtils.getTopKDistinctKudaf(3, Schema.INT32_SCHEMA);
+      TopKDistinctTestUtils.getTopKDistinctKudaf(3, Schema.OPTIONAL_INT32_SCHEMA);
 
   @Test
   public void shouldAggregateTopK() {
@@ -110,7 +110,7 @@ public class IntTopkDistinctKudafTest {
   public void shouldBeThreadSafe() {
     // Given:
     final TopkDistinctKudaf<Integer> intTopkDistinctKudaf =
-        TopKDistinctTestUtils.getTopKDistinctKudaf(12, Schema.INT32_SCHEMA);
+        TopKDistinctTestUtils.getTopKDistinctKudaf(12, Schema.OPTIONAL_INT32_SCHEMA);
 
     final List<Integer> values = ImmutableList.of(10, 30, 45, 10, 50, 60, 20, 70, 80, 35, 25);
 
@@ -138,7 +138,7 @@ public class IntTopkDistinctKudafTest {
     final int iterations = 1_000_000_000;
     final int topX = 10;
     final TopkDistinctKudaf<Integer> intTopkDistinctKudaf =
-        new TopkDistinctKudaf("TopkDistinctKudaf", 0, topX, Schema.INT32_SCHEMA, Integer.class);
+        new TopkDistinctKudaf("TopkDistinctKudaf", 0, topX, Schema.OPTIONAL_INT32_SCHEMA, Integer.class);
     final List<Integer> aggregate = new ArrayList<>();
     final long start = System.currentTimeMillis();
 
@@ -156,7 +156,7 @@ public class IntTopkDistinctKudafTest {
     final int iterations = 1_000_000_000;
     final int topX = 10;
     final TopkDistinctKudaf<Integer> intTopkDistinctKudaf =
-        TopKDistinctTestUtils.getTopKDistinctKudaf(topX, Schema.INT32_SCHEMA);
+        TopKDistinctTestUtils.getTopKDistinctKudaf(topX, Schema.OPTIONAL_INT32_SCHEMA);
 
     final List<Integer> aggregate1 = IntStream.range(0, topX)
         .mapToObj(v -> v % 2 == 0 ? v + 1 : v)

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/LongTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/LongTopkDistinctKudafTest.java
@@ -34,7 +34,7 @@ public class LongTopkDistinctKudafTest {
   private final List<Long> valuesArray = ImmutableList.of(10L, 30L, 45L, 10L, 50L, 60L, 20L, 60L, 80L, 35L, 25L,
       60L, 80L);
   private final TopkDistinctKudaf<Long> longTopkDistinctKudaf
-      = TopKDistinctTestUtils.getTopKDistinctKudaf(3, Schema.INT64_SCHEMA);
+      = TopKDistinctTestUtils.getTopKDistinctKudaf(3, Schema.OPTIONAL_INT64_SCHEMA);
 
   @Test
   public void shouldAggregateTopK() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/StringTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/StringTopkDistinctKudafTest.java
@@ -34,7 +34,7 @@ public class StringTopkDistinctKudafTest {
   private final List<String> valuesArray = ImmutableList.of("10", "30", "45", "10", "50", "60", "20", "60", "80", "35",
       "25", "60", "80");;
   private final TopkDistinctKudaf<String> stringTopkDistinctKudaf
-      = TopKDistinctTestUtils.getTopKDistinctKudaf(3, Schema.STRING_SCHEMA);
+      = TopKDistinctTestUtils.getTopKDistinctKudaf(3, Schema.OPTIONAL_STRING_SCHEMA);
 
   @Test
   public void shouldAggregateTopK() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -104,7 +104,7 @@ public class JsonFormatTest {
     topicProducer
             .produceInputData(inputTopic, orderDataProvider.data(), orderDataProvider.schema());
 
-    Schema messageSchema = SchemaBuilder.struct().field("MESSAGE", SchemaBuilder.STRING_SCHEMA).build();
+    Schema messageSchema = SchemaBuilder.struct().field("MESSAGE", SchemaBuilder.OPTIONAL_STRING_SCHEMA).build();
 
     GenericRow messageRow = new GenericRow(Collections.singletonList(
         "{\"log\":{\"@timestamp\":\"2017-05-30T16:44:22.175Z\",\"@version\":\"1\","

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -102,9 +102,9 @@ public class AggregateNodeTest {
   public void shouldBuildCorrectAggregateSchema() {
     SchemaKStream stream = build();
     final List<Field> expected = Arrays.asList(
-        new Field("COL0", 0, Schema.INT64_SCHEMA),
-        new Field("KSQL_COL_1", 1, Schema.FLOAT64_SCHEMA),
-        new Field("KSQL_COL_2", 2, Schema.INT64_SCHEMA));
+        new Field("COL0", 0, Schema.OPTIONAL_INT64_SCHEMA),
+        new Field("KSQL_COL_1", 1, Schema.OPTIONAL_FLOAT64_SCHEMA),
+        new Field("KSQL_COL_2", 2, Schema.OPTIONAL_INT64_SCHEMA));
     assertThat(stream.getSchema().fields(), equalTo(expected));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -106,9 +106,9 @@ public class KsqlBareOutputNodeTest {
   @Test
   public void shouldCreateCorrectSchema() {
     final Schema schema = stream.getSchema();
-    assertThat(schema.fields(), equalTo(Arrays.asList(new Field("COL0", 0, Schema.INT64_SCHEMA),
-        new Field("COL2", 1, Schema.STRING_SCHEMA),
-        new Field("COL3", 2, Schema.FLOAT64_SCHEMA))));
+    assertThat(schema.fields(), equalTo(Arrays.asList(new Field("COL0", 0, Schema.OPTIONAL_INT64_SCHEMA),
+        new Field("COL2", 1, Schema.OPTIONAL_STRING_SCHEMA),
+        new Field("COL3", 2, Schema.OPTIONAL_FLOAT64_SCHEMA))));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -68,11 +68,11 @@ public class KsqlStructuredDataOutputNodeTest {
   private static final String OUTPUT_NODE = "KSTREAM-SINK-0000000004";
 
   private final Schema schema = SchemaBuilder.struct()
-      .field("field1", Schema.STRING_SCHEMA)
-      .field("field2", Schema.STRING_SCHEMA)
-      .field("field3", Schema.STRING_SCHEMA)
-      .field("timestamp", Schema.INT64_SCHEMA)
-      .field("key", Schema.STRING_SCHEMA)
+      .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("field3", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("timestamp", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("key", Schema.OPTIONAL_STRING_SCHEMA)
       .build();
 
   private final KsqlStream dataSource = new KsqlStream("sqlExpression", "datasource",
@@ -154,11 +154,11 @@ public class KsqlStructuredDataOutputNodeTest {
     final List<Field> expected = Arrays.asList(
         new Field("ROWTIME", 0, Schema.OPTIONAL_INT64_SCHEMA),
         new Field("ROWKEY", 1, Schema.OPTIONAL_STRING_SCHEMA),
-        new Field("field1", 2, Schema.STRING_SCHEMA),
-        new Field("field2", 3, Schema.STRING_SCHEMA),
-        new Field("field3", 4, Schema.STRING_SCHEMA),
-        new Field("timestamp", 5, Schema.INT64_SCHEMA),
-        new Field("key", 6, Schema.STRING_SCHEMA));
+        new Field("field1", 2, Schema.OPTIONAL_STRING_SCHEMA),
+        new Field("field2", 3, Schema.OPTIONAL_STRING_SCHEMA),
+        new Field("field3", 4, Schema.OPTIONAL_STRING_SCHEMA),
+        new Field("timestamp", 5, Schema.OPTIONAL_INT64_SCHEMA),
+        new Field("key", 6, Schema.OPTIONAL_STRING_SCHEMA));
     final List<Field> fields = stream.outputNode().getSchema().fields();
     assertThat(fields, equalTo(expected));
   }
@@ -178,7 +178,7 @@ public class KsqlStructuredDataOutputNodeTest {
     createOutputNode(Collections.singletonMap(DdlConfig.PARTITION_BY_PROPERTY, "field2"));
     final SchemaKStream schemaKStream = buildStream();
     final Field keyField = schemaKStream.getKeyField();
-    assertThat(keyField, equalTo(new Field("field2", 1, Schema.STRING_SCHEMA)));
+    assertThat(keyField, equalTo(new Field("field2", 1, Schema.OPTIONAL_STRING_SCHEMA)));
     assertThat(schemaKStream.getSchema().fields(), equalTo(schema.fields()));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
@@ -60,8 +60,8 @@ public class ProjectNodeTest {
     final ProjectNode node = new ProjectNode(new PlanNodeId("1"),
         source,
         SchemaBuilder.struct()
-            .field("field1", Schema.STRING_SCHEMA)
-            .field("field2", Schema.STRING_SCHEMA)
+            .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
             .build(),
         Collections.singletonList(new BooleanLiteral("true")));
 
@@ -88,8 +88,8 @@ public class ProjectNodeTest {
     final ProjectNode node = new ProjectNode(new PlanNodeId("1"),
         source,
         SchemaBuilder.struct()
-            .field("field1", Schema.STRING_SCHEMA)
-            .field("field2", Schema.STRING_SCHEMA)
+            .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
             .build(),
         Arrays.asList(trueExpression, falseExpression));
 
@@ -103,7 +103,7 @@ public class ProjectNodeTest {
   }
 
   private void mockSourceNode() {
-    EasyMock.expect(source.getKeyField()).andReturn(new Field("field1", 0, Schema.STRING_SCHEMA));
+    EasyMock.expect(source.getKeyField()).andReturn(new Field("field1", 0, Schema.OPTIONAL_STRING_SCHEMA));
     EasyMock.expect(source.buildStream(anyObject(StreamsBuilder.class),
         anyObject(KsqlConfig.class),
         anyObject(KafkaTopicClient.class),

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
@@ -58,11 +58,11 @@ public class StructuredDataSourceNodeTest {
   private SchemaKStream stream;
   private StreamsBuilder builder;
   private final Schema schema = SchemaBuilder.struct()
-      .field("field1", Schema.STRING_SCHEMA)
-      .field("field2", Schema.STRING_SCHEMA)
-      .field("field3", Schema.STRING_SCHEMA)
-      .field("timestamp", Schema.INT64_SCHEMA)
-      .field("key", Schema.STRING_SCHEMA)
+      .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("field3", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("timestamp", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("key", Schema.OPTIONAL_STRING_SCHEMA)
       .build();
   private final StructuredDataSourceNode node = new StructuredDataSourceNode(
       new PlanNodeId("0"),
@@ -128,7 +128,7 @@ public class StructuredDataSourceNodeTest {
 
   @Test
   public void shouldExtracKeyField() {
-    assertThat(stream.getKeyField(), equalTo(new Field("key", 4, Schema.STRING_SCHEMA)));
+    assertThat(stream.getKeyField(), equalTo(new Field("key", 4, Schema.OPTIONAL_STRING_SCHEMA)));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -92,7 +92,7 @@ public class SchemaKGroupedTableTest {
           new KudafInitializer(1),
           Collections.singletonMap(
               0,
-              functionRegistry.getAggregate("SUM", Schema.INT64_SCHEMA)),
+              functionRegistry.getAggregate("SUM", Schema.OPTIONAL_INT64_SCHEMA)),
           Collections.singletonMap(0, 0),
           windowExpression,
           new KsqlJsonTopicSerDe().getGenericRowSerde(
@@ -112,9 +112,9 @@ public class SchemaKGroupedTableTest {
     try {
       Map<Integer, KsqlAggregateFunction> aggValToFunctionMap = new HashMap<>();
       aggValToFunctionMap.put(
-          0, functionRegistry.getAggregate("MAX", Schema.INT64_SCHEMA));
+          0, functionRegistry.getAggregate("MAX", Schema.OPTIONAL_INT64_SCHEMA));
       aggValToFunctionMap.put(
-          1, functionRegistry.getAggregate("MIN", Schema.INT64_SCHEMA));
+          1, functionRegistry.getAggregate("MIN", Schema.OPTIONAL_INT64_SCHEMA));
       kGroupedTable.aggregate(
           new KudafInitializer(1),
           aggValToFunctionMap,

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -119,7 +119,7 @@ public class SchemaKStreamTest {
     SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);
     assertThat(
         projectedSchemaKStream.getKeyField(),
-        equalTo(new Field("NEWKEY", 0, Schema.INT64_SCHEMA)));
+        equalTo(new Field("NEWKEY", 0, Schema.OPTIONAL_INT64_SCHEMA)));
   }
 
   @Test
@@ -135,7 +135,7 @@ public class SchemaKStreamTest {
     SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);
     assertThat(
         projectedSchemaKStream.getKeyField(),
-        equalTo(new Field("COL0", 1, Schema.INT64_SCHEMA)));
+        equalTo(new Field("COL0", 1, Schema.OPTIONAL_INT64_SCHEMA)));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -143,9 +143,9 @@ public class SchemaKTableTest {
     Assert.assertTrue(projectedSchemaKStream.getSchema()
                           .field("COL0").schema().type() == Schema.Type.INT64);
     Assert.assertTrue(projectedSchemaKStream.getSchema().fields().get(1).schema() == Schema
-        .INT32_SCHEMA);
+        .OPTIONAL_INT32_SCHEMA);
     Assert.assertTrue(projectedSchemaKStream.getSchema().fields().get(2).schema() == Schema
-        .FLOAT64_SCHEMA);
+        .OPTIONAL_FLOAT64_SCHEMA);
 
     Assert.assertTrue(projectedSchemaKStream.getSourceSchemaKStreams().get(0) ==
                       initialSchemaKTable);

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
@@ -46,10 +46,10 @@ public class ExpressionTypeManagerTest {
         metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
         functionRegistry = new InternalFunctionRegistry();
         schema = SchemaBuilder.struct()
-                .field("TEST1.COL0", SchemaBuilder.INT64_SCHEMA)
-                .field("TEST1.COL1", SchemaBuilder.STRING_SCHEMA)
-                .field("TEST1.COL2", SchemaBuilder.STRING_SCHEMA)
-                .field("TEST1.COL3", SchemaBuilder.FLOAT64_SCHEMA);
+                .field("TEST1.COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+                .field("TEST1.COL1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+                .field("TEST1.COL2", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+                .field("TEST1.COL3", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA);
     }
 
     private Analysis analyzeQuery(String queryStr) {
@@ -138,7 +138,7 @@ public class ExpressionTypeManagerTest {
             functionRegistry);
 
         assertThat(expressionTypeManager.getExpressionSchema(analysis.getSelectExpressions().get(0)),
-            equalTo(Schema.STRING_SCHEMA));
+            equalTo(Schema.OPTIONAL_STRING_SCHEMA));
 
     }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
@@ -35,8 +35,8 @@ public class ItemDataProvider extends TestDataProvider {
   private static final String key = "ID";
 
   private static final Schema schema = SchemaBuilder.struct()
-      .field("ID", SchemaBuilder.STRING_SCHEMA)
-      .field("DESCRIPTION", SchemaBuilder.STRING_SCHEMA).build();
+      .field("ID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .field("DESCRIPTION", SchemaBuilder.OPTIONAL_STRING_SCHEMA).build();
 
   private static final Map<String, GenericRow> data = new ItemDataProvider().buildData();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
@@ -35,13 +35,13 @@ public class OrderDataProvider extends TestDataProvider {
   private static final String key = "ORDERTIME";
 
   private static final Schema schema = SchemaBuilder.struct()
-      .field("ORDERTIME", SchemaBuilder.INT64_SCHEMA)
-      .field("ORDERID", SchemaBuilder.STRING_SCHEMA)
-      .field("ITEMID", SchemaBuilder.STRING_SCHEMA)
-      .field("ORDERUNITS", SchemaBuilder.FLOAT64_SCHEMA)
-      .field("TIMESTAMP", Schema.STRING_SCHEMA)
-      .field("PRICEARRAY", SchemaBuilder.array(SchemaBuilder.FLOAT64_SCHEMA))
-      .field("KEYVALUEMAP", SchemaBuilder.map(SchemaBuilder.STRING_SCHEMA, SchemaBuilder.FLOAT64_SCHEMA)).build();
+      .field("ORDERTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+      .field("ORDERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .field("ITEMID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .field("ORDERUNITS", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
+      .field("TIMESTAMP", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("PRICEARRAY", SchemaBuilder.array(SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA).optional().build())
+      .field("KEYVALUEMAP", SchemaBuilder.map(SchemaBuilder.OPTIONAL_STRING_SCHEMA, SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)).optional().build();
 
   private static final Map<String, GenericRow> data = new OrderDataProvider().buildData();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
@@ -33,9 +33,9 @@ public class PageViewDataProvider extends TestDataProvider {
   private static final String key = "PAGEID";
 
   private static final Schema schema = SchemaBuilder.struct()
-      .field("VIEWTIME", SchemaBuilder.INT64_SCHEMA)
-      .field("USERID", SchemaBuilder.STRING_SCHEMA)
-      .field("PAGEID", SchemaBuilder.STRING_SCHEMA).build();
+      .field("VIEWTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+      .field("USERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .field("PAGEID", SchemaBuilder.OPTIONAL_STRING_SCHEMA).build();
 
   private static final Map<String, GenericRow> data = new PageViewDataProvider().buildData();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/SerDeUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/SerDeUtilTest.java
@@ -102,21 +102,21 @@ public class SerDeUtilTest {
   public void shouldReturnCorrectKsqlSchema() {
     Schema schema = SerDeUtil.getSchemaFromAvro(avroSchemaStr);
     assertThat("Incorrect schema.", schema.fields().size(), equalTo(8));
-    assertThat("Incorrect field schema.", schema.fields().get(0).schema(), equalTo(Schema.STRING_SCHEMA));
+    assertThat("Incorrect field schema.", schema.fields().get(0).schema(), equalTo(Schema.OPTIONAL_STRING_SCHEMA));
     assertThat("Incorrect field schema.", schema.fields().get(1).schema(), equalTo(Schema
-                                                                                       .STRING_SCHEMA));
+                                                                                       .OPTIONAL_STRING_SCHEMA));
     assertThat("Incorrect field schema.", schema.fields().get(2).schema(), equalTo(Schema
-                                                                                       .STRING_SCHEMA));
+                                                                                       .OPTIONAL_STRING_SCHEMA));
     assertThat("Incorrect field schema.", schema.fields().get(3).schema(), equalTo(Schema
-                                                                                       .STRING_SCHEMA));
+                                                                                       .OPTIONAL_STRING_SCHEMA));
     assertThat("Incorrect field schema.", schema.fields().get(4).schema(), equalTo(Schema
-                                                                                       .STRING_SCHEMA));
+                                                                                       .OPTIONAL_STRING_SCHEMA));
     assertThat("Incorrect field schema.", schema.fields().get(5).schema(), equalTo(Schema
-                                                                                       .FLOAT64_SCHEMA));
+                                                                                       .OPTIONAL_FLOAT64_SCHEMA));
     assertThat("Incorrect field schema.", schema.fields().get(6).schema(), equalTo(Schema
-                                                                                       .FLOAT64_SCHEMA));
+                                                                                       .OPTIONAL_FLOAT64_SCHEMA));
     assertThat("Incorrect field schema.", schema.fields().get(7).schema(), equalTo(Schema
-                                                                                       .STRING_SCHEMA));
+                                                                                       .OPTIONAL_STRING_SCHEMA));
   }
 
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
@@ -31,10 +31,10 @@ public class UserDataProvider extends TestDataProvider {
   private static final String key = "USERID";
 
   private static final Schema schema = SchemaBuilder.struct()
-      .field("REGISTERTIME", SchemaBuilder.INT64_SCHEMA)
-      .field("GENDER", SchemaBuilder.STRING_SCHEMA)
-      .field("REGIONID", SchemaBuilder.STRING_SCHEMA)
-      .field("USERID", SchemaBuilder.STRING_SCHEMA).build();
+      .field("REGISTERTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+      .field("GENDER", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .field("REGIONID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .field("USERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA).build();
 
   private static final Map<String, GenericRow> data = new UserDataProvider().buildData();
 

--- a/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -36,14 +36,14 @@ public class MetaStoreFixture {
     final MetaStore metaStore = new MetaStoreImpl(functionRegistry);
 
     SchemaBuilder schemaBuilder1 = SchemaBuilder.struct()
-        .field("ROWTIME", SchemaBuilder.INT64_SCHEMA)
-        .field("ROWKEY", SchemaBuilder.INT64_SCHEMA)
-        .field("COL0", SchemaBuilder.INT64_SCHEMA)
-        .field("COL1", SchemaBuilder.STRING_SCHEMA)
-        .field("COL2", SchemaBuilder.STRING_SCHEMA)
-        .field("COL3", SchemaBuilder.FLOAT64_SCHEMA)
-        .field("COL4", SchemaBuilder.array(SchemaBuilder.FLOAT64_SCHEMA))
-        .field("COL5", SchemaBuilder.map(SchemaBuilder.STRING_SCHEMA, SchemaBuilder.FLOAT64_SCHEMA));
+        .field("ROWTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+        .field("ROWKEY", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+        .field("COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+        .field("COL1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("COL2", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("COL3", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
+        .field("COL4", SchemaBuilder.array(SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA).optional().build())
+        .field("COL5", SchemaBuilder.map(SchemaBuilder.OPTIONAL_STRING_SCHEMA, SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA).optional().build());
 
     KsqlTopic
         ksqlTopic1 =
@@ -60,13 +60,13 @@ public class MetaStoreFixture {
     metaStore.putSource(ksqlStream);
 
     SchemaBuilder schemaBuilder2 = SchemaBuilder.struct()
-        .field("ROWTIME", SchemaBuilder.INT64_SCHEMA)
-        .field("ROWKEY", SchemaBuilder.INT64_SCHEMA)
-        .field("COL0", SchemaBuilder.INT64_SCHEMA)
-        .field("COL1", SchemaBuilder.STRING_SCHEMA)
-        .field("COL2", SchemaBuilder.STRING_SCHEMA)
-        .field("COL3", SchemaBuilder.FLOAT64_SCHEMA)
-        .field("COL4", SchemaBuilder.BOOLEAN_SCHEMA);
+        .field("ROWTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+        .field("ROWKEY", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+        .field("COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+        .field("COL1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("COL2", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("COL3", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
+        .field("COL4", SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA);
 
     KsqlTopic
         ksqlTopic2 =
@@ -85,10 +85,10 @@ public class MetaStoreFixture {
     metaStore.putSource(ksqlTable);
 
     SchemaBuilder schemaBuilderOrders = SchemaBuilder.struct()
-        .field("ORDERTIME", SchemaBuilder.INT64_SCHEMA)
-        .field("ORDERID", SchemaBuilder.STRING_SCHEMA)
-        .field("ITEMID", SchemaBuilder.STRING_SCHEMA)
-        .field("ORDERUNITS", SchemaBuilder.FLOAT64_SCHEMA);
+        .field("ORDERTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+        .field("ORDERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("ITEMID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("ORDERUNITS", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA);
 
     KsqlTopic
         ksqlTopicOrders =

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -1564,7 +1564,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
       if (selectItem instanceof SingleColumn) {
         SingleColumn singleColumn = (SingleColumn) selectItem;
         String fieldName = singleColumn.getAlias().get();
-        dataSource = dataSource.field(fieldName, Schema.BOOLEAN_SCHEMA);
+        dataSource = dataSource.field(fieldName, Schema.OPTIONAL_BOOLEAN_SCHEMA);
       }
     }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/TypeUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/TypeUtil.java
@@ -71,22 +71,22 @@ public class TypeUtil {
   public static Schema getTypeSchema(final Type ksqlType) {
     switch (ksqlType.getKsqlType()) {
       case BOOLEAN:
-        return Schema.BOOLEAN_SCHEMA;
+        return Schema.OPTIONAL_BOOLEAN_SCHEMA;
       case INTEGER:
-        return Schema.INT32_SCHEMA;
+        return Schema.OPTIONAL_INT32_SCHEMA;
       case BIGINT:
-        return Schema.INT64_SCHEMA;
+        return Schema.OPTIONAL_INT64_SCHEMA;
       case DOUBLE:
-        return Schema.FLOAT64_SCHEMA;
+        return Schema.OPTIONAL_FLOAT64_SCHEMA;
       case STRING:
-        return Schema.STRING_SCHEMA;
+        return Schema.OPTIONAL_STRING_SCHEMA;
       case ARRAY:
         return SchemaBuilder.array(
           getTypeSchema(((Array) ksqlType).getItemType())
-          );
+          ).optional().build();
       case MAP:
-        return SchemaBuilder.map(Schema.STRING_SCHEMA,
-                                 getTypeSchema(((Map) ksqlType).getValueType()));
+        return SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA,
+                                 getTypeSchema(((Map) ksqlType).getValueType())).optional().build();
       case STRUCT:
         return buildStructSchema((Struct) ksqlType);
 
@@ -100,7 +100,7 @@ public class TypeUtil {
     for (Pair<String, Type> field: struct.getItems()) {
       strcutSchemaBuilder.field(field.getLeft(), getTypeSchema(field.getRight()));
     }
-    return strcutSchemaBuilder.build();
+    return strcutSchemaBuilder.optional().build();
   }
 
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/util/TypeUtilTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/util/TypeUtilTest.java
@@ -38,26 +38,26 @@ public class TypeUtilTest {
 
   @Test
   public void shouldGetCorrectPrimitiveKsqlType() throws Exception {
-    Type type0 = TypeUtil.getKsqlType(Schema.BOOLEAN_SCHEMA);
+    Type type0 = TypeUtil.getKsqlType(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     assertThat(type0.getKsqlType(), equalTo(Type.KsqlType.BOOLEAN));
 
-    Type type1 = TypeUtil.getKsqlType(Schema.INT32_SCHEMA);
+    Type type1 = TypeUtil.getKsqlType(Schema.OPTIONAL_INT32_SCHEMA);
     assertThat(type1.getKsqlType(), equalTo(Type.KsqlType.INTEGER));
 
-    Type type2 = TypeUtil.getKsqlType(Schema.FLOAT64_SCHEMA);
+    Type type2 = TypeUtil.getKsqlType(Schema.OPTIONAL_FLOAT64_SCHEMA);
     assertThat(type2.getKsqlType(), equalTo(Type.KsqlType.DOUBLE));
 
-    Type type3 = TypeUtil.getKsqlType(Schema.STRING_SCHEMA);
+    Type type3 = TypeUtil.getKsqlType(Schema.OPTIONAL_STRING_SCHEMA);
     assertThat(type3.getKsqlType(), equalTo(Type.KsqlType.STRING));
 
-    Type type4 = TypeUtil.getKsqlType(Schema.INT64_SCHEMA);
+    Type type4 = TypeUtil.getKsqlType(Schema.OPTIONAL_INT64_SCHEMA);
     assertThat(type4.getKsqlType(), equalTo(Type.KsqlType.BIGINT));
   }
 
   @Test
   public void shouldGetCorrectArrayKsqlType() throws Exception {
 
-    Schema arraySchema = SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build();
+    Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build();
     Type type = TypeUtil.getKsqlType(arraySchema);
     assertThat(type.getKsqlType(), equalTo(Type.KsqlType.ARRAY));
     assertThat(type, instanceOf(Array.class));
@@ -67,7 +67,7 @@ public class TypeUtilTest {
   @Test
   public void shouldGetCorrectMapKsqlType() throws Exception {
 
-    Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA).build();
+    Schema mapSchema = SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build();
     Type type = TypeUtil.getKsqlType(mapSchema);
     assertThat(type.getKsqlType(), equalTo(Type.KsqlType.MAP));
     assertThat(type, instanceOf(Map.class));
@@ -78,25 +78,25 @@ public class TypeUtilTest {
   @Test
   public void shouldGetCorrectStructKsqlType() throws Exception {
 
-    Schema arraySchema = SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build();
+    Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build();
     Type type4 = TypeUtil.getKsqlType(arraySchema);
     assertThat(type4.getKsqlType(), equalTo(Type.KsqlType.ARRAY));
     assertThat(type4, instanceOf(Array.class));
     assertThat(((Array) type4).getItemType().getKsqlType(), equalTo(Type.KsqlType.DOUBLE));
 
-    Schema mapSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA).build();
+    Schema mapSchema = SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build();
     Type type5 = TypeUtil.getKsqlType(mapSchema);
     assertThat(type5.getKsqlType(), equalTo(Type.KsqlType.MAP));
     assertThat(type5, instanceOf(Map.class));
     assertThat(((Map) type5).getValueType().getKsqlType(), equalTo(Type.KsqlType.DOUBLE));
 
     Schema structSchema1 = SchemaBuilder.struct()
-        .field("COL1", Schema.FLOAT64_SCHEMA)
-        .field("COL2", Schema.STRING_SCHEMA)
-        .field("COL3", Schema.BOOLEAN_SCHEMA)
+        .field("COL1", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("COL2", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("COL3", Schema.OPTIONAL_BOOLEAN_SCHEMA)
         .field("COL4", arraySchema)
         .field("COL5", mapSchema)
-        .build();
+        .optional().build();
     Type type6 = TypeUtil.getKsqlType(structSchema1);
     assertThat(type6.getKsqlType(), equalTo(Type.KsqlType.STRUCT));
     assertThat(type6, instanceOf(Struct.class));
@@ -111,9 +111,9 @@ public class TypeUtilTest {
                                                                                         .MAP));
 
     Schema structSchema2 = SchemaBuilder.struct()
-        .field("COL1", Schema.FLOAT64_SCHEMA)
-        .field("COL2", Schema.STRING_SCHEMA)
-        .field("COL3", Schema.BOOLEAN_SCHEMA)
+        .field("COL1", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("COL2", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("COL3", Schema.OPTIONAL_BOOLEAN_SCHEMA)
         .field("COL4", arraySchema)
         .field("COL5", mapSchema)
         .field("COL6", structSchema1)
@@ -140,22 +140,22 @@ public class TypeUtilTest {
   public void shouldGetCorrectPrimitiveSchema() throws Exception {
 
     Schema schema1 = TypeUtil.getTypeSchema(new PrimitiveType(Type.KsqlType.BIGINT));
-    assertThat(schema1, equalTo(Schema.INT64_SCHEMA));
+    assertThat(schema1, equalTo(Schema.OPTIONAL_INT64_SCHEMA));
 
     Schema schema2 = TypeUtil.getTypeSchema(new PrimitiveType(Type.KsqlType.BOOLEAN));
-    assertThat(schema2, equalTo(Schema.BOOLEAN_SCHEMA));
+    assertThat(schema2, equalTo(Schema.OPTIONAL_BOOLEAN_SCHEMA));
 
     Schema schema3 = TypeUtil.getTypeSchema(new PrimitiveType(Type.KsqlType.INTEGER));
-    assertThat(schema3, equalTo(Schema.INT32_SCHEMA));
+    assertThat(schema3, equalTo(Schema.OPTIONAL_INT32_SCHEMA));
 
     Schema schema4 = TypeUtil.getTypeSchema(new PrimitiveType(Type.KsqlType.DOUBLE));
-    assertThat(schema4, equalTo(Schema.FLOAT64_SCHEMA));
+    assertThat(schema4, equalTo(Schema.OPTIONAL_FLOAT64_SCHEMA));
 
     Schema schema5 = TypeUtil.getTypeSchema(new PrimitiveType(Type.KsqlType.STRING));
-    assertThat(schema5, equalTo(Schema.STRING_SCHEMA));
+    assertThat(schema5, equalTo(Schema.OPTIONAL_STRING_SCHEMA));
 
     Schema schema6 = TypeUtil.getTypeSchema(new PrimitiveType(Type.KsqlType.BIGINT));
-    assertThat(schema6, equalTo(Schema.INT64_SCHEMA));
+    assertThat(schema6, equalTo(Schema.OPTIONAL_INT64_SCHEMA));
 
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -190,11 +190,11 @@ public class KsqlResourceTest {
     }
 
     private static void addTestTopicAndSources(MetaStore metaStore, KafkaTopicClient kafkaTopicClient) {
-      Schema schema1 = SchemaBuilder.struct().field("S1_F1", Schema.BOOLEAN_SCHEMA);
+      Schema schema1 = SchemaBuilder.struct().field("S1_F1", Schema.OPTIONAL_BOOLEAN_SCHEMA);
       addSource(
           metaStore, kafkaTopicClient, DataSource.DataSourceType.KTABLE,
           "TEST_TABLE", "KAFKA_TOPIC_1", "KSQL_TOPIC_1", schema1);
-      Schema schema2 = SchemaBuilder.struct().field("S2_F1", Schema.STRING_SCHEMA);
+      Schema schema2 = SchemaBuilder.struct().field("S2_F1", Schema.OPTIONAL_STRING_SCHEMA);
       addSource(
           metaStore, kafkaTopicClient, DataSource.DataSourceType.KSTREAM,
           "TEST_STREAM", "KAFKA_TOPIC_2", "KSQL_TOPIC_2", schema2);
@@ -351,8 +351,8 @@ public class KsqlResourceTest {
     KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
 
     Schema schema = SchemaBuilder.struct()
-        .field("FIELD1", Schema.BOOLEAN_SCHEMA)
-        .field("FIELD2", Schema.STRING_SCHEMA);
+        .field("FIELD1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .field("FIELD2", Schema.OPTIONAL_STRING_SCHEMA);
     TestKsqlResourceUtil.addSource(
         testResource.getKsqlEngine().getMetaStore(), testResource.getKsqlEngine().getTopicClient(),
         DataSource.DataSourceType.KSTREAM, "new_stream", "new_topic",
@@ -383,8 +383,8 @@ public class KsqlResourceTest {
     KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
 
     Schema schema = SchemaBuilder.struct()
-        .field("FIELD1", Schema.BOOLEAN_SCHEMA)
-        .field("FIELD2", Schema.STRING_SCHEMA);
+        .field("FIELD1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .field("FIELD2", Schema.OPTIONAL_STRING_SCHEMA);
     TestKsqlResourceUtil.addSource(
         testResource.getKsqlEngine().getMetaStore(), testResource.getKsqlEngine().getTopicClient(),
         DataSource.DataSourceType.KTABLE, "new_table", "new_topic",

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -191,7 +191,7 @@ public class StreamedQueryResourceTest {
             mockKafkaTopicClient, null, Collections.emptyMap());
     reset(mockOutputNode);
     expect(mockOutputNode.getSchema())
-        .andReturn(SchemaBuilder.struct().field("f1", SchemaBuilder.INT32_SCHEMA));
+        .andReturn(SchemaBuilder.struct().field("f1", SchemaBuilder.OPTIONAL_INT32_SCHEMA));
     expect(mockKsqlEngine.buildMultipleQueries(queryString, requestStreamsProperties))
         .andReturn(Collections.singletonList(queuedQueryMetadata));
     mockKsqlEngine.removeTemporaryQuery(queuedQueryMetadata);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
@@ -119,7 +119,7 @@ public class PollingSubscriptionTest {
       super(
           MoreExecutors.listeningDecorator(exec),
           subscriber,
-          SchemaBuilder.STRING_SCHEMA
+          SchemaBuilder.OPTIONAL_STRING_SCHEMA
       );
     }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -92,7 +92,7 @@ public class QueryStreamWriterTest {
     drainCapture = newCapture();
     limitHandlerCapture = newCapture();
 
-    Schema schema = SchemaBuilder.struct().field("col1", Schema.STRING_SCHEMA).build();
+    Schema schema = SchemaBuilder.struct().field("col1", Schema.OPTIONAL_STRING_SCHEMA).build();
 
     final KafkaStreams kStreams = niceMock(KafkaStreams.class);
 

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
@@ -140,7 +140,7 @@ public class KsqlJsonDeserializer implements Deserializer<GenericRow> {
       final Map<String, Object> columnMap) {
     return columnMap.entrySet().stream()
         .collect(Collectors.toMap(
-            e -> enforceFieldType(Schema.STRING_SCHEMA, e.getKey()).toString(),
+            e -> enforceFieldType(Schema.OPTIONAL_STRING_SCHEMA, e.getKey()).toString(),
             e -> enforceFieldType(fieldSchema.valueSchema(), e.getValue())
         ));
   }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonSerializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonSerializer.java
@@ -17,20 +17,14 @@
 package io.confluent.ksql.serde.json;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.util.KsqlException;
 
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.json.JsonConverter;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 public class KsqlJsonSerializer implements Serializer<GenericRow> {
@@ -42,7 +36,7 @@ public class KsqlJsonSerializer implements Serializer<GenericRow> {
    * Default constructor needed by Kafka
    */
   public KsqlJsonSerializer(final Schema schema) {
-    this.schema = makeOptional(schema);
+    this.schema = schema;
     jsonConverter = new JsonConverter();
     jsonConverter.configure(Collections.singletonMap("schemas.enable", false), false);
   }
@@ -60,134 +54,12 @@ public class KsqlJsonSerializer implements Serializer<GenericRow> {
     try {
       final Struct struct = new Struct(schema);
       for (int i = 0; i < data.getColumns().size(); i++) {
-        Schema structSchema = schema.fields().get(i).schema();
-        if (structSchema.type() == Schema.Type.STRUCT) {
-          Field structField = schema.fields().get(i);
-          struct.put(structField, updateStructSchema(
-              (Struct) data.getColumns().get(i),
-              structField.schema()));
-        } else {
-          struct.put(schema.fields().get(i), data.getColumns().get(i));
-        }
+        struct.put(schema.fields().get(i), data.getColumns().get(i));
       }
 
       return jsonConverter.fromConnectData(topic, schema, struct);
     } catch (Exception e) {
       throw new SerializationException("Error serializing JSON message", e);
-    }
-  }
-
-  private Schema makeOptional(final Schema schema) {
-    switch (schema.type()) {
-      case BOOLEAN:
-        return Schema.OPTIONAL_BOOLEAN_SCHEMA;
-      case INT32:
-        return Schema.OPTIONAL_INT32_SCHEMA;
-      case INT64:
-        return Schema.OPTIONAL_INT64_SCHEMA;
-      case FLOAT64:
-        return Schema.OPTIONAL_FLOAT64_SCHEMA;
-      case STRING:
-        return Schema.OPTIONAL_STRING_SCHEMA;
-      case ARRAY:
-        return SchemaBuilder.array(makeOptional(schema.valueSchema())).optional().build();
-      case MAP:
-        return SchemaBuilder.map(schema.keySchema(), makeOptional(schema.valueSchema()))
-            .optional().build();
-      case STRUCT:
-        final SchemaBuilder schemaBuilder = new SchemaBuilder(Schema.Type.STRUCT);
-        schema.fields()
-            .forEach(field -> schemaBuilder.field(field.name(), makeOptional(field.schema())));
-        return schemaBuilder.optional().build();
-      default:
-        throw new KsqlException("Invalid type in schema: " + schema);
-    }
-  }
-
-  /**
-   * Temporary work around until schema comparison is fixed.
-   * Currently, when we put a value in a struct the schema object should match too
-   * however, although the schemas are the same but the objects do not match.
-   * This is to overcome this problem.
-   * The reason is that we have been using non-optional schema fields in our schema.
-   * We will need to switch to optional fields and that will eliminate the need to make
-   * the schema update here.
-   */
-  private Struct updateStructSchema(final Struct struct, final Schema schema) {
-    if (!compareSchemas(schema, struct.schema())) {
-      throw new KsqlException("Incompatible schemas: " + schema + ", " + struct.schema());
-    }
-    final Struct updatedStruct = new Struct(schema);
-    for (Field field : schema.fields()) {
-      switch (field.schema().type()) {
-        case STRUCT:
-          updatedStruct.put(field.name(),
-              updateStructSchema((Struct) struct.get(field.name()), field.schema()));
-          break;
-        case ARRAY:
-          updatedStruct.put(field.name(),
-              updateArraySchema((List) struct.get(field.name()), field.schema()));
-          break;
-        case MAP:
-          updatedStruct.put(field.name(),
-              updateMapSchema((Map) struct.get(field.name()), field.schema()));
-          break;
-        default:
-          updatedStruct.put(field.name(), struct.get(field.name()));
-      }
-    }
-
-    return updatedStruct;
-  }
-
-  private List<?> updateArraySchema(List<?> elements, Schema arraySchema) {
-    switch (arraySchema.valueSchema().type()) {
-      case STRUCT:
-        return elements.stream()
-            .map(item -> updateStructSchema((Struct) item, arraySchema.valueSchema()))
-            .collect(Collectors.toList());
-      case ARRAY:
-        return elements.stream()
-            .map(item -> updateArraySchema((List) item, arraySchema.valueSchema()))
-            .collect(Collectors.toList());
-      case MAP:
-        return elements.stream()
-            .map(item -> updateMapSchema((Map<String, ?>) item, arraySchema.valueSchema()))
-            .collect(Collectors.toList());
-      default:
-        return elements;
-    }
-  }
-
-  private Map<String, ?> updateMapSchema(final Map<String, ?> map, final Schema mapSchema) {
-    switch (mapSchema.valueSchema().type()) {
-      case STRUCT:
-        return map.entrySet().stream()
-            .collect(Collectors.toMap(
-                Entry::getKey,
-                e -> updateStructSchema((Struct) e.getValue(),
-                    mapSchema.valueSchema())
-            ));
-      case ARRAY:
-        return map.entrySet().stream()
-            .collect(Collectors.toMap(
-                Entry::getKey,
-                e -> updateArraySchema((List) e.getValue(),
-                    mapSchema.valueSchema())
-            ));
-      case MAP:
-        return map.entrySet().stream()
-            .collect(Collectors.toMap(
-                Entry::getKey,
-                e -> updateMapSchema((Map<String, ?>) e.getValue(),
-                    mapSchema.valueSchema())
-            ));
-      default:
-        return map.entrySet().stream()
-            .collect(Collectors.toMap(
-                Entry::getKey,
-                Entry::getValue
-            ));
     }
   }
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroDeserializerTest.java
@@ -85,12 +85,12 @@ public class KsqlGenericRowAvroDeserializerTest {
     genericRecord.put("mapCol", Collections.singletonMap("key1", 100.0));
 
     schema = SchemaBuilder.struct()
-        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
-        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA)
-        .field("arraycol".toUpperCase(), SchemaBuilder.array(org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA))
-        .field("mapcol".toUpperCase(), SchemaBuilder.map(org.apache.kafka.connect.data.Schema.STRING_SCHEMA, org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA))
+        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA)
+        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("arraycol".toUpperCase(), SchemaBuilder.array(org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
+        .field("mapcol".toUpperCase(), SchemaBuilder.map(org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA, org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .build();
   }
 
@@ -155,10 +155,10 @@ public class KsqlGenericRowAvroDeserializerTest {
   @Test
   public void shouldDeserializeIfThereAreRedundantFields() {
     org.apache.kafka.connect.data.Schema newSchema = SchemaBuilder.struct()
-        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
-        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA)
+        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA)
+        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA)
         .build();
     SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     List<Object> columns = Arrays.asList(1511897796092L, 1L, "item_1", 10.0, new Double[]{100.0},

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
@@ -48,12 +48,12 @@ public class KsqlGenericRowAvroSerializerTest {
   public void before() {
 
     schema = SchemaBuilder.struct()
-        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
-        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA)
-        .field("arraycol".toUpperCase(), SchemaBuilder.array(org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA))
-        .field("mapcol".toUpperCase(), SchemaBuilder.map(org.apache.kafka.connect.data.Schema.STRING_SCHEMA, org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA))
+        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA)
+        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("arraycol".toUpperCase(), SchemaBuilder.array(org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
+        .field("mapcol".toUpperCase(), SchemaBuilder.map(org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA, org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .build();
   }
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializerTest.java
@@ -36,10 +36,10 @@ public class KsqlDelimitedDeserializerTest {
   public void before() {
 
     orderSchema = SchemaBuilder.struct()
-        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
-        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA)
+        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA)
+        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA)
         .build();
   }
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializerTest.java
@@ -38,10 +38,10 @@ public class KsqlDelimitedSerializerTest {
   public void before() {
 
     orderSchema = SchemaBuilder.struct()
-        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
-        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA)
+        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA)
+        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA)
         .build();
   }
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonDeserializerTest.java
@@ -42,12 +42,12 @@ public class KsqlJsonDeserializerTest {
   public void before() {
 
     orderSchema = SchemaBuilder.struct()
-        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
-        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA)
-        .field("arraycol".toUpperCase(), SchemaBuilder.array(org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA))
-        .field("mapcol".toUpperCase(), SchemaBuilder.map(org.apache.kafka.connect.data.Schema.STRING_SCHEMA, org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA))
+        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA)
+        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("arraycol".toUpperCase(), SchemaBuilder.array(org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
+        .field("mapcol".toUpperCase(), SchemaBuilder.map(org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA, org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .build();
   }
 
@@ -89,10 +89,10 @@ public class KsqlJsonDeserializerTest {
     byte[] jsonBytes = objectMapper.writeValueAsBytes(orderRow);
 
     Schema newOrderSchema = SchemaBuilder.struct()
-        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
-        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA)
+        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA)
+        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA)
         .build();
     KsqlJsonDeserializer ksqlJsonDeserializer = new KsqlJsonDeserializer(newOrderSchema, false);
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
@@ -52,15 +52,15 @@ public class KsqlJsonSerializerTest {
   public void before() {
 
     orderSchema = SchemaBuilder.struct()
-        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
-        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
-        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA)
+        .field("ordertime".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("orderid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+        .field("itemid".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA)
+        .field("orderunits".toUpperCase(), org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA)
         .field("arraycol".toUpperCase(),
-            SchemaBuilder.array(org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA))
+            SchemaBuilder.array(org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .field("mapcol".toUpperCase(), SchemaBuilder
-            .map(org.apache.kafka.connect.data.Schema.STRING_SCHEMA,
-                org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA))
+            .map(org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA,
+                org.apache.kafka.connect.data.Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .build();
   }
 
@@ -92,32 +92,32 @@ public class KsqlJsonSerializerTest {
 
   private Schema getSchemaWithStruct() {
     addressSchema = SchemaBuilder.struct()
-        .field("NUMBER", Schema.INT64_SCHEMA)
-        .field("STREET", Schema.STRING_SCHEMA)
-        .field("CITY", Schema.STRING_SCHEMA)
-        .field("STATE", Schema.STRING_SCHEMA)
-        .field("ZIPCODE", Schema.INT64_SCHEMA)
-        .build();
+        .field("NUMBER", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("STREET", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("CITY", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("STATE", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("ZIPCODE", Schema.OPTIONAL_INT64_SCHEMA)
+        .optional().build();
 
     categorySchema = SchemaBuilder.struct()
-        .field("ID", Schema.INT64_SCHEMA)
-        .field("NAME", Schema.STRING_SCHEMA)
-        .build();
+        .field("ID", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("NAME", Schema.OPTIONAL_STRING_SCHEMA)
+        .optional().build();
 
     itemSchema = SchemaBuilder.struct()
-        .field("ITEMID", Schema.INT64_SCHEMA)
-        .field("NAME", Schema.STRING_SCHEMA)
-        .field("CATEGORIES", SchemaBuilder.array(categorySchema))
-        .build();
+        .field("ITEMID", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("NAME", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("CATEGORIES", SchemaBuilder.array(categorySchema).optional().build())
+        .optional().build();
 
     SchemaBuilder schemaBuilder = SchemaBuilder.struct();
     Schema schema = schemaBuilder
-        .field("ordertime", Schema.INT64_SCHEMA)
-        .field("orderid", Schema.INT64_SCHEMA)
+        .field("ordertime", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("orderid", Schema.OPTIONAL_INT64_SCHEMA)
         .field("itemid", itemSchema)
-        .field("orderunits", Schema.INT32_SCHEMA)
-        .field("arraycol", schemaBuilder.array(Schema.FLOAT64_SCHEMA))
-        .field("mapcol", schemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA))
+        .field("orderunits", Schema.OPTIONAL_INT32_SCHEMA)
+        .field("arraycol", schemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
+        .field("mapcol", schemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .field("address", addressSchema).build();
 
     return schema;


### PR DESCRIPTION
This PR switches the schema field schema to optional since we support null values. This will simplify using the connect data structure.
Although the PR includes many files the changes are fairly simple and mostly includes updating the field schema from non optional to optional.

