### PR TITLE
Query rewrite feature using ast

### DIFF
--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
@@ -750,7 +750,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
   protected Node visitTable(Table node, Object context) {
     Map<String, Expression> properties = node.getProperties().entrySet().stream()
         .collect(Collectors.toMap(
-            e -> e.getKey(),
+            Map.Entry::getKey,
             e -> (Expression) process(e.getValue(), context)
         ));
     if (node.getLocation().isPresent()) {
@@ -999,7 +999,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
           node.isNotExists(),
           node.getProperties().entrySet().stream()
               .collect(Collectors.toMap(
-                  e -> e.getKey(),
+                  Map.Entry::getKey,
                   e -> (Expression) process(e.getValue(), context)
               ))
       );
@@ -1012,7 +1012,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
           node.isNotExists(),
           node.getProperties().entrySet().stream()
               .collect(Collectors.toMap(
-                  e -> e.getKey(),
+                  Map.Entry::getKey,
                   e -> (Expression) process(e.getValue(), context)
               ))
       );
@@ -1027,7 +1027,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
           node.isNotExists(),
           node.getProperties().entrySet().stream()
               .collect(Collectors.toMap(
-                  e -> e.getKey(),
+                  Map.Entry::getKey,
                   e -> (Expression) process(e.getValue(), context)
               )),
           node.getPartitionByColumn().isPresent()
@@ -1042,7 +1042,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
           node.isNotExists(),
           node.getProperties().entrySet().stream()
               .collect(Collectors.toMap(
-                  e -> e.getKey(),
+                  Map.Entry::getKey,
                   e -> (Expression) process(e.getValue(), context)
               )),
           node.getPartitionByColumn().isPresent()
@@ -1064,7 +1064,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
           node.isNotExists(),
           node.getProperties().entrySet().stream()
               .collect(Collectors.toMap(
-                  e -> e.getKey(),
+                  Map.Entry::getKey,
                   e -> (Expression) process(e.getValue(), context)
               )));
     } else {
@@ -1075,7 +1075,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
           node.isNotExists(),
           node.getProperties().entrySet().stream()
               .collect(Collectors.toMap(
-                  e -> e.getKey(),
+                  Map.Entry::getKey,
                   e -> (Expression) process(e.getValue(), context)
               )));
     }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
@@ -1,0 +1,1236 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.parser.rewrite;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import io.confluent.ksql.parser.tree.AliasedRelation;
+import io.confluent.ksql.parser.tree.AllColumns;
+import io.confluent.ksql.parser.tree.ArithmeticBinaryExpression;
+import io.confluent.ksql.parser.tree.ArithmeticUnaryExpression;
+import io.confluent.ksql.parser.tree.BetweenPredicate;
+import io.confluent.ksql.parser.tree.BinaryLiteral;
+import io.confluent.ksql.parser.tree.BooleanLiteral;
+import io.confluent.ksql.parser.tree.Cast;
+import io.confluent.ksql.parser.tree.ComparisonExpression;
+import io.confluent.ksql.parser.tree.CreateStream;
+import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
+import io.confluent.ksql.parser.tree.CreateTable;
+import io.confluent.ksql.parser.tree.CreateTableAsSelect;
+import io.confluent.ksql.parser.tree.CreateView;
+import io.confluent.ksql.parser.tree.DecimalLiteral;
+import io.confluent.ksql.parser.tree.DefaultAstVisitor;
+import io.confluent.ksql.parser.tree.Delete;
+import io.confluent.ksql.parser.tree.DereferenceExpression;
+import io.confluent.ksql.parser.tree.DoubleLiteral;
+import io.confluent.ksql.parser.tree.DropTable;
+import io.confluent.ksql.parser.tree.DropView;
+import io.confluent.ksql.parser.tree.ExistsPredicate;
+import io.confluent.ksql.parser.tree.Explain;
+import io.confluent.ksql.parser.tree.ExplainOption;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.Extract;
+import io.confluent.ksql.parser.tree.FieldReference;
+import io.confluent.ksql.parser.tree.FrameBound;
+import io.confluent.ksql.parser.tree.FunctionCall;
+import io.confluent.ksql.parser.tree.GenericLiteral;
+import io.confluent.ksql.parser.tree.GroupBy;
+import io.confluent.ksql.parser.tree.GroupingElement;
+import io.confluent.ksql.parser.tree.HoppingWindowExpression;
+import io.confluent.ksql.parser.tree.InListExpression;
+import io.confluent.ksql.parser.tree.InPredicate;
+import io.confluent.ksql.parser.tree.InsertInto;
+import io.confluent.ksql.parser.tree.IntervalLiteral;
+import io.confluent.ksql.parser.tree.IsNotNullPredicate;
+import io.confluent.ksql.parser.tree.IsNullPredicate;
+import io.confluent.ksql.parser.tree.Join;
+import io.confluent.ksql.parser.tree.KsqlWindowExpression;
+import io.confluent.ksql.parser.tree.LambdaExpression;
+import io.confluent.ksql.parser.tree.LikePredicate;
+import io.confluent.ksql.parser.tree.Literal;
+import io.confluent.ksql.parser.tree.LogicalBinaryExpression;
+import io.confluent.ksql.parser.tree.LongLiteral;
+import io.confluent.ksql.parser.tree.Node;
+import io.confluent.ksql.parser.tree.NotExpression;
+import io.confluent.ksql.parser.tree.NullIfExpression;
+import io.confluent.ksql.parser.tree.NullLiteral;
+import io.confluent.ksql.parser.tree.QualifiedNameReference;
+import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.parser.tree.QueryBody;
+import io.confluent.ksql.parser.tree.QuerySpecification;
+import io.confluent.ksql.parser.tree.Relation;
+import io.confluent.ksql.parser.tree.RenameColumn;
+import io.confluent.ksql.parser.tree.SampledRelation;
+import io.confluent.ksql.parser.tree.SearchedCaseExpression;
+import io.confluent.ksql.parser.tree.Select;
+import io.confluent.ksql.parser.tree.SelectItem;
+import io.confluent.ksql.parser.tree.SessionWindowExpression;
+import io.confluent.ksql.parser.tree.SetOperation;
+import io.confluent.ksql.parser.tree.SetSession;
+import io.confluent.ksql.parser.tree.ShowCatalogs;
+import io.confluent.ksql.parser.tree.ShowColumns;
+import io.confluent.ksql.parser.tree.ShowCreate;
+import io.confluent.ksql.parser.tree.ShowFunctions;
+import io.confluent.ksql.parser.tree.ShowPartitions;
+import io.confluent.ksql.parser.tree.SimpleCaseExpression;
+import io.confluent.ksql.parser.tree.SimpleGroupBy;
+import io.confluent.ksql.parser.tree.SingleColumn;
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.parser.tree.Statements;
+import io.confluent.ksql.parser.tree.StringLiteral;
+import io.confluent.ksql.parser.tree.Struct;
+import io.confluent.ksql.parser.tree.SubqueryExpression;
+import io.confluent.ksql.parser.tree.SubscriptExpression;
+import io.confluent.ksql.parser.tree.SymbolReference;
+import io.confluent.ksql.parser.tree.Table;
+import io.confluent.ksql.parser.tree.TableElement;
+import io.confluent.ksql.parser.tree.TableSubquery;
+import io.confluent.ksql.parser.tree.TimeLiteral;
+import io.confluent.ksql.parser.tree.TimestampLiteral;
+import io.confluent.ksql.parser.tree.TumblingWindowExpression;
+import io.confluent.ksql.parser.tree.Values;
+import io.confluent.ksql.parser.tree.WhenClause;
+import io.confluent.ksql.parser.tree.Window;
+import io.confluent.ksql.parser.tree.WindowExpression;
+import io.confluent.ksql.parser.tree.WindowFrame;
+import io.confluent.ksql.parser.tree.WithQuery;
+import io.confluent.ksql.util.KsqlException;
+
+public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
+
+  protected Node visitNode(Node node, Object context) {
+    return null;
+  }
+
+  protected Node visitExpression(Expression node, Object context) {
+    return node;
+  }
+
+  protected Node visitExtract(Extract node, Object context) {
+
+    if (node.getLocation().isPresent()) {
+      return new Extract(node.getLocation().get(),
+          (Expression) process(node.getExpression(), context),
+          node.getField());
+    } else {
+      return new Extract((Expression) process(node.getExpression(), context),
+          node.getField());
+    }
+
+  }
+
+  protected Node visitArithmeticBinary(ArithmeticBinaryExpression node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new ArithmeticBinaryExpression(node.getLocation().get(),
+          node.getType(),
+          (Expression) process(node.getLeft(), context),
+          (Expression) process(node.getRight(), context));
+    } else {
+      return new ArithmeticBinaryExpression(node.getType(),
+          (Expression) process(node.getLeft(), context),
+          (Expression) process(node.getRight(), context));
+    }
+
+  }
+
+  protected Node visitBetweenPredicate(BetweenPredicate node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new BetweenPredicate(node.getLocation().get(),
+          (Expression) process(node.getValue(), context),
+          (Expression) process(node.getMin(), context),
+          (Expression) process(node.getMax(), context));
+    } else {
+      return new BetweenPredicate((Expression) process(node.getValue(), context),
+          (Expression) process(node.getMin(), context),
+          (Expression) process(node.getMax(), context));
+    }
+
+  }
+
+  protected Node visitComparisonExpression(ComparisonExpression node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new ComparisonExpression(node.getLocation().get(),
+          node.getType(),
+          (Expression) process(node.getLeft(), context),
+          (Expression) process(node.getRight(), context));
+    } else {
+      return new ComparisonExpression(node.getType(),
+          (Expression) process(node.getLeft(), context),
+          (Expression) process(node.getRight(), context));
+    }
+
+  }
+
+  protected Node visitLiteral(Literal node, Object context) {
+    return visitExpression(node, context);
+  }
+
+  protected Node visitDoubleLiteral(DoubleLiteral node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new DoubleLiteral(node.getLocation().get(), String.valueOf(node.getValue()));
+    } else {
+      return new DoubleLiteral(String.valueOf(node.getValue()));
+    }
+
+  }
+
+  protected Node visitDecimalLiteral(DecimalLiteral node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new DecimalLiteral(node.getLocation().get(), node.getValue());
+    } else {
+      return new DecimalLiteral(node.getValue());
+    }
+  }
+
+  protected Node visitStatements(Statements node, Object context) {
+    return new Statements(
+        node.statementList
+            .stream()
+            .map(s -> (Statement) process(s, context))
+            .collect(Collectors.toList())
+    );
+  }
+
+  protected Node visitStatement(Statement node, Object context) {
+    return visitNode(node, context);
+  }
+
+  protected Node visitQuery(Query node, Object context) {
+    return new Query((QueryBody) process(node.getQueryBody(), context),
+        node.getLimit());
+  }
+
+  protected Node visitExplain(Explain node, Object context) {
+    return visitStatement(node, context);
+  }
+
+  protected Node visitShowCatalogs(ShowCatalogs node, Object context) {
+    return visitStatement(node, context);
+  }
+
+  protected Node visitShowColumns(ShowColumns node, Object context) {
+    return visitStatement(node, context);
+  }
+
+  protected Node visitShowPartitions(ShowPartitions node, Object context) {
+    return visitStatement(node, context);
+  }
+
+  protected Node visitShowCreate(ShowCreate node, Object context) {
+    return visitStatement(node, context);
+  }
+
+  protected Node visitShowFunctions(ShowFunctions node, Object context) {
+    return visitStatement(node, context);
+  }
+
+  protected Node visitSetSession(SetSession node, Object context) {
+    return visitStatement(node, context);
+  }
+
+  protected Node visitGenericLiteral(GenericLiteral node, Object context) {
+    return visitLiteral(node, context);
+  }
+
+  protected Node visitTimeLiteral(TimeLiteral node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new TimeLiteral(node.getLocation().get(), node.getValue());
+    } else {
+      return new TimeLiteral(node.getValue());
+    }
+
+  }
+
+  protected Node visitExplainOption(ExplainOption node, Object context) {
+    return visitNode(node, context);
+  }
+
+  protected Node visitWithQuery(WithQuery node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new WithQuery(node.getLocation().get(),
+          node.getName(),
+          (Query) process(node.getQuery(), context),
+          node.getColumnNames());
+    } else {
+      return new WithQuery(node.getName(),
+          (Query) process(node.getQuery(), context),
+          node.getColumnNames());
+    }
+
+  }
+
+  protected Node visitSelect(Select node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new Select(node.getLocation().get(),
+          node.isDistinct(),
+          node.getSelectItems()
+              .stream()
+              .map(selectItem -> (SelectItem) process(selectItem, context))
+              .collect(Collectors.toList())
+      );
+    } else {
+      return new Select(node.isDistinct(),
+          node.getSelectItems()
+              .stream()
+              .map(selectItem -> (SelectItem) process(selectItem, context))
+              .collect(Collectors.toList())
+      );
+    }
+
+  }
+
+  protected Node visitRelation(Relation node, Object context) {
+    return visitNode(node, context);
+  }
+
+  protected Node visitQueryBody(QueryBody node, Object context) {
+    return visitRelation(node, context);
+  }
+
+  protected Node visitQuerySpecification(QuerySpecification node, Object context) {
+    Optional<WindowExpression> windowExpression = node.getWindowExpression().isPresent()
+        ? Optional.ofNullable((WindowExpression) process(node.getWindowExpression().get(), context))
+        : Optional.empty();
+    Optional<Expression> where = node.getWhere().isPresent()
+        ? Optional.ofNullable((Expression) process(node.getWhere().get(),
+        context))
+        : Optional.empty();
+
+    Optional<GroupBy> groupBy = node.getGroupBy().isPresent()
+        ? Optional.ofNullable((GroupBy) process(node.getGroupBy().get(), context))
+        : Optional.empty();
+
+    Optional<Expression> having = node.getHaving().isPresent()
+        ? Optional.ofNullable((Expression) process(node.getHaving().get(), context))
+        : Optional.empty();
+
+    if (node.getLocation().isPresent()) {
+      return new QuerySpecification(
+          node.getLocation().get(),
+          (Select) process(node.getSelect(), context),
+          (Relation) process(node.getInto(), context),
+          node.isShouldCreateInto(),
+          (Relation) process(node.getFrom(), context),
+          windowExpression,
+          where,
+          groupBy,
+          having,
+          node.getLimit()
+      );
+    } else {
+      return new QuerySpecification(
+          (Select) process(node.getSelect(), context),
+          (Relation) process(node.getInto(), context),
+          node.isShouldCreateInto(),
+          (Relation) process(node.getFrom(), context),
+          windowExpression,
+          where,
+          groupBy,
+          having,
+          node.getLimit()
+      );
+    }
+
+  }
+
+  protected Node visitSetOperation(SetOperation node, Object context) {
+    return visitQueryBody(node, context);
+  }
+
+  protected Node visitTimestampLiteral(TimestampLiteral node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new TimeLiteral(node.getLocation().get(), node.getValue());
+    } else {
+      return new TimeLiteral(node.getValue());
+    }
+  }
+
+  protected Node visitWhenClause(WhenClause node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new WhenClause(node.getLocation().get(),
+          (Expression) process(node.getOperand(), context),
+          (Expression) process(node.getResult(), context));
+    } else {
+      return new WhenClause((Expression) process(node.getOperand(), context),
+          (Expression) process(node.getResult(), context));
+    }
+
+  }
+
+  protected Node visitIntervalLiteral(IntervalLiteral node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new IntervalLiteral(node.getLocation().get(),
+          node.getValue(),
+          node.getSign(),
+          node.getStartField(),
+          node.getEndField()
+      );
+    } else {
+      return new IntervalLiteral(node.getValue(),
+          node.getSign(),
+          node.getStartField(),
+          node.getEndField()
+      );
+    }
+
+  }
+
+  protected Node visitInPredicate(InPredicate node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new InPredicate(node.getLocation().get(),
+          (Expression) process(node.getValue(), context),
+          (Expression) process(node.getValueList(), context));
+    } else {
+      return new InPredicate((Expression) process(node.getValue(), context),
+          (Expression) process(node.getValueList(), context));
+    }
+
+  }
+
+  protected Node visitFunctionCall(FunctionCall node, Object context) {
+    Optional<Window> window = node.getWindow().isPresent()
+        ? Optional.ofNullable((Window) process(node.getWindow().get(), context))
+        : Optional.empty();
+
+    if (node.getLocation().isPresent()) {
+      return new FunctionCall(node.getLocation().get(),
+          node.getName(),
+          window,
+          node.isDistinct(),
+          node.getArguments()
+              .stream()
+              .map(arg -> (Expression) process(arg, context))
+              .collect(Collectors.toList())
+      );
+    } else {
+      return new FunctionCall(node.getName(),
+          window,
+          node.isDistinct(),
+          node.getArguments()
+              .stream()
+              .map(arg -> (Expression) process(arg, context))
+              .collect(Collectors.toList())
+      );
+    }
+
+  }
+
+  protected Node visitLambdaExpression(LambdaExpression node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new LambdaExpression(node.getLocation().get(),
+          node.getArguments(),
+          (Expression) process(node.getBody(), context)
+      );
+    } else {
+      return new LambdaExpression(node.getArguments(),
+          (Expression) process(node.getBody(), context)
+      );
+    }
+  }
+
+  protected Node visitSimpleCaseExpression(SimpleCaseExpression node, Object context) {
+    Optional<Expression> defaultValue = node.getDefaultValue().isPresent()
+        ? Optional.ofNullable((Expression) process(node.getDefaultValue().get(), context))
+        : Optional.empty();
+    if (node.getLocation().isPresent()) {
+      return new SimpleCaseExpression(node.getLocation().get(),
+          (Expression) process(node.getOperand(), context),
+          node.getWhenClauses()
+              .stream()
+              .map(whenClause ->
+                  (WhenClause) process(whenClause, context))
+              .collect(Collectors.toList()),
+          defaultValue
+      );
+    } else {
+      return new SimpleCaseExpression((Expression) process(node.getOperand(), context),
+          node.getWhenClauses()
+              .stream()
+              .map(whenClause ->
+                  (WhenClause) process(whenClause, context))
+              .collect(Collectors.toList()),
+          defaultValue
+      );
+    }
+
+  }
+
+  protected Node visitStringLiteral(StringLiteral node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new StringLiteral(node.getLocation().get(),
+          node.getValue());
+    } else {
+      return new StringLiteral(node.getValue());
+    }
+
+  }
+
+  protected Node visitBinaryLiteral(BinaryLiteral node, Object context) {
+    // May need some changes.
+    if (node.getLocation().isPresent()) {
+      return new BinaryLiteral(node.getLocation().get(), node.getValue().toString());
+    } else {
+      return new BinaryLiteral(node.getValue().toString());
+    }
+
+  }
+
+  protected Node visitBooleanLiteral(BooleanLiteral node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new BooleanLiteral(node.getLocation().get(), String.valueOf(node.getValue()));
+    } else {
+      return new BooleanLiteral(String.valueOf(node.getValue()));
+    }
+
+
+  }
+
+  protected Node visitInListExpression(InListExpression node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new InListExpression(node.getLocation().get(),
+          node.getValues().stream()
+              .map(value -> (Expression) process(value, context))
+              .collect(Collectors.toList())
+      );
+    } else {
+      return new InListExpression(node.getValues().stream()
+          .map(value -> (Expression) process(value, context))
+          .collect(Collectors.toList())
+      );
+    }
+
+  }
+
+  protected Node visitQualifiedNameReference(QualifiedNameReference node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new QualifiedNameReference(node.getLocation().get(),
+          node.getName());
+    } else {
+      return new QualifiedNameReference(node.getName());
+    }
+
+  }
+
+  protected Node visitDereferenceExpression(DereferenceExpression node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new DereferenceExpression(node.getLocation().get(),
+          (Expression) process(node.getBase(), context),
+          node.getFieldName()
+      );
+    } else {
+      return new DereferenceExpression((Expression) process(node.getBase(), context),
+          node.getFieldName()
+      );
+    }
+
+  }
+
+  protected Node visitNullIfExpression(NullIfExpression node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new NullIfExpression(node.getLocation().get(),
+          (Expression) process(node.getFirst(), context),
+          (Expression) process(node.getSecond(), context));
+    } else {
+      return new NullIfExpression((Expression) process(node.getFirst(), context),
+          (Expression) process(node.getSecond(), context));
+    }
+
+  }
+
+  protected Node visitNullLiteral(NullLiteral node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new NullLiteral(node.getLocation().get());
+    } else {
+      return new NullLiteral();
+    }
+
+  }
+
+  protected Node visitArithmeticUnary(ArithmeticUnaryExpression node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new ArithmeticUnaryExpression(
+          node.getLocation().get(),
+          node.getSign(),
+          (Expression) process(node.getValue(), context)
+      );
+    } else {
+      return new ArithmeticUnaryExpression(
+          node.getSign(),
+          (Expression) process(node.getValue(), context)
+      );
+    }
+
+  }
+
+  protected Node visitNotExpression(NotExpression node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new NotExpression(node.getLocation().get(),
+          (Expression) process(node.getValue(), context)
+      );
+    } else {
+      return new NotExpression((Expression) process(node.getValue(), context)
+      );
+    }
+
+  }
+
+  protected Node visitSelectItem(SelectItem node, Object context) {
+    return visitNode(node, context);
+  }
+
+  protected Node visitSingleColumn(SingleColumn node, Object context) {
+
+    if (node.getLocation().isPresent()) {
+      return new SingleColumn(node.getLocation().get(),
+          (Expression) process(node.getExpression(), context),
+          node.getAlias()
+      );
+    } else {
+      return new SingleColumn(
+          (Expression) process(node.getExpression(), context),
+          node.getAlias()
+      );
+    }
+
+  }
+
+  protected Node visitAllColumns(AllColumns node, Object context) {
+    if (node.getLocation().isPresent()) {
+      if (node.getPrefix().isPresent()) {
+        return new AllColumns(node.getLocation().get(), node.getPrefix().get());
+      } else {
+        return new AllColumns(node.getLocation().get());
+      }
+
+    } else {
+      if (node.getPrefix().isPresent()) {
+        return new AllColumns(node.getLocation().get());
+      } else {
+        throw new KsqlException("Cannot have both localtion and prefix null in AllColumns AST "
+            + "node.");
+      }
+
+    }
+
+  }
+
+  protected Node visitSearchedCaseExpression(SearchedCaseExpression node, Object context) {
+    Optional<Expression> defaultValue = node.getDefaultValue().isPresent()
+        ? Optional.ofNullable((Expression) process(node.getDefaultValue().get(), context))
+        : Optional.empty();
+    if (node.getLocation().isPresent()) {
+      return new SearchedCaseExpression(
+          node.getLocation().get(),
+          node.getWhenClauses()
+              .stream().map(whenClause -> (WhenClause) process(whenClause, context))
+              .collect(Collectors.toList()),
+          defaultValue
+      );
+    } else {
+      return new SearchedCaseExpression(
+          node.getWhenClauses()
+              .stream().map(whenClause -> (WhenClause) process(whenClause, context))
+              .collect(Collectors.toList()),
+          defaultValue
+      );
+    }
+
+  }
+
+  protected Node visitLikePredicate(LikePredicate node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new LikePredicate(node.getLocation().get(),
+          (Expression) process(node.getValue(), context),
+          (Expression) process(node.getPattern(), context),
+          node.getEscape() != null
+              ? (Expression) process(node.getEscape(), context)
+              : null
+      );
+    } else {
+      return new LikePredicate((Expression) process(node.getValue(), context),
+          (Expression) process(node.getPattern(), context),
+          node.getEscape() != null
+              ? (Expression) process(node.getEscape(), context)
+              : null
+      );
+    }
+
+  }
+
+  protected Node visitIsNotNullPredicate(IsNotNullPredicate node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new IsNotNullPredicate(node.getLocation().get(),
+          (Expression) process(node.getValue(), context)
+      );
+    } else {
+      return new IsNotNullPredicate((Expression) process(node.getValue(), context)
+      );
+    }
+
+  }
+
+  protected Node visitIsNullPredicate(IsNullPredicate node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new IsNullPredicate(node.getLocation().get(),
+          (Expression) process(node.getValue(), context)
+      );
+    } else {
+      return new IsNullPredicate((Expression) process(node.getValue(), context)
+      );
+    }
+
+  }
+
+  protected Node visitSubscriptExpression(SubscriptExpression node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new SubscriptExpression(node.getLocation().get(),
+          (Expression) process(node.getBase(), context),
+          (Expression) process(node.getIndex(), context)
+      );
+    } else {
+      return new SubscriptExpression((Expression) process(node.getBase(), context),
+          (Expression) process(node.getIndex(), context)
+      );
+    }
+
+  }
+
+  protected Node visitLongLiteral(LongLiteral node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new LongLiteral(node.getLocation().get(), String.valueOf(node.getValue()));
+    } else {
+      return new LongLiteral(String.valueOf(node.getValue()));
+    }
+
+  }
+
+  protected Node visitLogicalBinaryExpression(LogicalBinaryExpression node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new LogicalBinaryExpression(node.getLocation().get(),
+          node.getType(),
+          (Expression) process(node.getLeft(), context),
+          (Expression) process(node.getRight(), context)
+      );
+    } else {
+      return new LogicalBinaryExpression(node.getType(),
+          (Expression) process(node.getLeft(), context),
+          (Expression) process(node.getRight(), context)
+      );
+    }
+
+  }
+
+  protected Node visitSubqueryExpression(SubqueryExpression node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new SubqueryExpression(node.getLocation().get(),
+          (Query) process(node.getQuery(), context));
+    } else {
+      return new SubqueryExpression((Query) process(node.getQuery(), context));
+    }
+
+  }
+
+  protected Node visitTable(Table node, Object context) {
+    Map<String, Expression> properties = node.getProperties().entrySet().stream()
+        .collect(Collectors.toMap(
+            e -> e.getKey(),
+            e -> (Expression) process(e.getValue(), context)
+        ));
+    if (node.getLocation().isPresent()) {
+      return new Table(node.getLocation().get(),
+          node.getName(),
+          node.isStdOut,
+          properties);
+    } else {
+      return new Table(node.getName(),
+          node.isStdOut,
+          properties);
+    }
+
+  }
+
+  protected Node visitValues(Values node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new Values(node.getLocation().get(),
+          node.getRows().stream()
+              .map(row -> (Expression) process(row, context))
+              .collect(Collectors.toList())
+      );
+    } else {
+      return new Values(node.getRows().stream()
+          .map(row -> (Expression) process(row, context))
+          .collect(Collectors.toList())
+      );
+    }
+
+  }
+
+  protected Node visitStruct(Struct node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new Struct(node.getLocation().get(),
+          node.getItems());
+    } else {
+      return new Struct(node.getItems());
+    }
+
+  }
+
+  protected Node visitTableSubquery(TableSubquery node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new TableSubquery(node.getLocation().get(),
+          (Query) process(node.getQuery(), context)
+      );
+    } else {
+      return new TableSubquery((Query) process(node.getQuery(), context)
+      );
+    }
+
+  }
+
+  protected Node visitAliasedRelation(AliasedRelation node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new AliasedRelation(node.getLocation().get(),
+          (Relation) process(node.getRelation(), context),
+          node.getAlias(),
+          node.getColumnNames());
+    } else {
+      return new AliasedRelation((Relation) process(node.getRelation(), context),
+          node.getAlias(),
+          node.getColumnNames());
+    }
+
+  }
+
+  protected Node visitSampledRelation(SampledRelation node, Object context) {
+
+    Optional<List<Expression>> columnsToStratifyOn = node.getColumnsToStratifyOn().isPresent()
+        ? Optional.ofNullable(
+        node.getColumnsToStratifyOn().get()
+            .stream()
+            .map(expression -> (Expression) process(expression, context))
+            .collect(Collectors.toList()))
+        : Optional.empty();
+    if (node.getLocation().isPresent()) {
+      return new SampledRelation(node.getLocation().get(),
+          (Relation) process(node.getRelation(), context),
+          node.getType(),
+          (Expression) process(node.getSamplePercentage(), context),
+          node.isRescaled(),
+          columnsToStratifyOn
+      );
+    } else {
+      return new SampledRelation((Relation) process(node.getRelation(), context),
+          node.getType(),
+          (Expression) process(node.getSamplePercentage(), context),
+          node.isRescaled(),
+          columnsToStratifyOn
+      );
+    }
+
+  }
+
+  protected Node visitJoin(Join node, Object context) {
+    //TODO: Will have to look into Criteria later (includes Expression)
+    if (node.getLocation().isPresent()) {
+      return new Join(node.getLocation().get(),
+          node.getType(),
+          (Relation) process(node.getLeft(), context),
+          (Relation) process(node.getRight(), context),
+          node.getCriteria()
+      );
+    } else {
+      return new Join(node.getType(),
+          (Relation) process(node.getLeft(), context),
+          (Relation) process(node.getRight(), context),
+          node.getCriteria()
+      );
+    }
+
+  }
+
+  protected Node visitExists(ExistsPredicate node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new ExistsPredicate(node.getLocation().get(),
+          (Query) process(node.getSubquery(), context)
+      );
+    } else {
+      return new ExistsPredicate((Query) process(node.getSubquery(), context)
+      );
+    }
+
+  }
+
+  protected Node visitCast(Cast node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new Cast(node.getLocation().get(),
+          (Expression) process(node.getExpression(), context),
+          node.getType()
+      );
+    } else {
+      return new Cast((Expression) process(node.getExpression(), context),
+          node.getType()
+      );
+    }
+
+  }
+
+  protected Node visitFieldReference(FieldReference node, Object context) {
+    return new FieldReference(node.getFieldIndex());
+  }
+
+  protected Node visitWindowExpression(WindowExpression node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new WindowExpression(
+          node.getLocation().get(),
+          node.getWindowName(),
+          (KsqlWindowExpression) process(node.getKsqlWindowExpression(), context));
+    } else {
+      return new WindowExpression(
+          node.getWindowName(),
+          (KsqlWindowExpression) process(node.getKsqlWindowExpression(), context));
+    }
+
+  }
+
+  protected Node visitTumblingWindowExpression(TumblingWindowExpression node, Object context) {
+    return new TumblingWindowExpression(node.getSize(), node.getSizeUnit());
+  }
+
+  protected Node visitHoppingWindowExpression(HoppingWindowExpression node, Object context) {
+    return new HoppingWindowExpression(node.getSize(),
+        node.getSizeUnit(),
+        node.getAdvanceBy(),
+        node.getAdvanceByUnit());
+  }
+
+  protected Node visitSessionWindowExpression(SessionWindowExpression node, Object context) {
+    return new SessionWindowExpression(node.getGap(),
+        node.getSizeUnit());
+  }
+
+  protected Node visitWindow(Window node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new Window(node.getLocation().get(),
+          node.getWindowName(),
+          (WindowExpression) process(node.getWindowExpression(), context)
+      );
+    } else {
+      return new Window(node.getWindowName(),
+          (WindowExpression) process(node.getWindowExpression(), context)
+      );
+    }
+
+  }
+
+  protected Node visitWindowFrame(WindowFrame node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new WindowFrame(
+          node.getLocation().get(),
+          node.getType(),
+          (FrameBound) process(node.getStart(), context),
+          node.getEnd().isPresent()
+              ? Optional.ofNullable((FrameBound) process(node.getEnd().get(), context))
+              : Optional.empty()
+      );
+    } else {
+      return new WindowFrame(
+          node.getType(),
+          (FrameBound) process(node.getStart(), context),
+          node.getEnd().isPresent()
+              ? Optional.ofNullable((FrameBound) process(node.getEnd().get(), context))
+              : Optional.empty()
+      );
+    }
+  }
+
+  protected Node visitFrameBound(FrameBound node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new FrameBound(node.getLocation().get(),
+          node.getType(),
+          node.getValue().isPresent()
+              ? (Expression) process(node.getValue().get(), context)
+              : null
+      );
+    } else {
+      return new FrameBound(node.getType(),
+          node.getValue().isPresent()
+              ? (Expression) process(node.getValue().get(), context)
+              : null
+      );
+    }
+  }
+
+  protected Node visitTableElement(TableElement node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new TableElement(node.getLocation().get(),
+          node.getName(),
+          node.getType());
+    } else {
+      return new TableElement(node.getName(),
+          node.getType());
+    }
+  }
+
+  protected Node visitCreateStream(CreateStream node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new CreateStream(
+          node.getLocation().get(),
+          node.getName(),
+          node.getElements().stream()
+              .map(tableElement -> (TableElement) process(tableElement, context))
+              .collect(Collectors.toList()),
+          node.isNotExists(),
+          node.getProperties().entrySet().stream()
+              .collect(Collectors.toMap(
+                  e -> e.getKey(),
+                  e -> (Expression) process(e.getValue(), context)
+              ))
+      );
+    } else {
+      return new CreateStream(
+          node.getName(),
+          node.getElements().stream()
+              .map(tableElement -> (TableElement) process(tableElement, context))
+              .collect(Collectors.toList()),
+          node.isNotExists(),
+          node.getProperties().entrySet().stream()
+              .collect(Collectors.toMap(
+                  e -> e.getKey(),
+                  e -> (Expression) process(e.getValue(), context)
+              ))
+      );
+    }
+  }
+
+  protected Node visitCreateStreamAsSelect(CreateStreamAsSelect node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new CreateStreamAsSelect(node.getLocation().get(),
+          node.getName(),
+          (Query) process(node.getQuery(), context),
+          node.isNotExists(),
+          node.getProperties().entrySet().stream()
+              .collect(Collectors.toMap(
+                  e -> e.getKey(),
+                  e -> (Expression) process(e.getValue(), context)
+              )),
+          node.getPartitionByColumn().isPresent()
+              ? Optional.ofNullable(
+              (Expression) process(node.getPartitionByColumn().get(),
+                  context))
+              : Optional.empty()
+      );
+    } else {
+      return new CreateStreamAsSelect(node.getName(),
+          (Query) process(node.getQuery(), context),
+          node.isNotExists(),
+          node.getProperties().entrySet().stream()
+              .collect(Collectors.toMap(
+                  e -> e.getKey(),
+                  e -> (Expression) process(e.getValue(), context)
+              )),
+          node.getPartitionByColumn().isPresent()
+              ? Optional.ofNullable(
+              (Expression) process(node.getPartitionByColumn().get(),
+                  context))
+              : Optional.empty()
+      );
+    }
+  }
+
+  protected Node visitCreateTable(CreateTable node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new CreateTable(node.getLocation().get(),
+          node.getName(),
+          node.getElements().stream()
+              .map(tableElement -> (TableElement) process(tableElement, context))
+              .collect(Collectors.toList()),
+          node.isNotExists(),
+          node.getProperties().entrySet().stream()
+              .collect(Collectors.toMap(
+                  e -> e.getKey(),
+                  e -> (Expression) process(e.getValue(), context)
+              )));
+    } else {
+      return new CreateTable(node.getName(),
+          node.getElements().stream()
+              .map(tableElement -> (TableElement) process(tableElement, context))
+              .collect(Collectors.toList()),
+          node.isNotExists(),
+          node.getProperties().entrySet().stream()
+              .collect(Collectors.toMap(
+                  e -> e.getKey(),
+                  e -> (Expression) process(e.getValue(), context)
+              )));
+    }
+
+  }
+
+  protected Node visitCreateTableAsSelect(CreateTableAsSelect node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new CreateTableAsSelect(node.getLocation().get(),
+          node.getName(),
+          (Query) process(node.getQuery(), context),
+          node.isNotExists(),
+          node.getProperties().entrySet().stream()
+              .collect(Collectors.toMap(
+                  e -> e.getKey(),
+                  e -> (Expression) process(e.getValue(), context)
+              )));
+    } else {
+      return new CreateTableAsSelect(node.getName(),
+          (Query) process(node.getQuery(), context),
+          node.isNotExists(),
+          node.getProperties().entrySet().stream()
+              .collect(Collectors.toMap(
+                  e -> e.getKey(),
+                  e -> (Expression) process(e.getValue(), context)
+              )));
+    }
+
+  }
+
+  protected Node visitInsertInto(InsertInto node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new InsertInto(node.getLocation().get(),
+          node.getTarget(),
+          (Query) process(node.getQuery(), context),
+          node.getPartitionByColumn().isPresent()
+              ? Optional.ofNullable(
+              (Expression) process(node.getPartitionByColumn().get(),
+                  context))
+              : Optional.empty());
+    } else {
+      return new InsertInto(node.getTarget(),
+          (Query) process(node.getQuery(), context),
+          node.getPartitionByColumn().isPresent()
+              ? Optional.ofNullable(
+              (Expression) process(node.getPartitionByColumn().get(),
+                  context))
+              : Optional.empty());
+    }
+  }
+
+  protected Node visitDropTable(DropTable node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new DropTable(node.getLocation().get(),
+          node.getTableName(),
+          node.getIfExists(),
+          node.isDeleteTopic());
+    } else {
+      return new DropTable(node.getTableName(),
+          node.getIfExists(),
+          node.isDeleteTopic());
+    }
+  }
+
+  protected Node visitRenameColumn(RenameColumn node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new RenameColumn(node.getLocation().get(),
+          node.getTable(),
+          node.getSource(),
+          node.getTarget()
+      );
+    } else {
+      return new RenameColumn(node.getTable(),
+          node.getSource(),
+          node.getTarget()
+      );
+    }
+
+  }
+
+  protected Node visitCreateView(CreateView node, Object context) {
+    return visitStatement(node, context);
+  }
+
+  protected Node visitDropView(DropView node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new DropView(node.getLocation().get(),
+          node.getName(),
+          node.isExists());
+    } else {
+      return new DropView(node.getName(),
+          node.isExists());
+    }
+
+  }
+
+  protected Node visitDelete(Delete node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new Delete(node.getLocation().get(),
+          (Table) process(node.getTable(), context),
+          node.getWhere().isPresent()
+              ? Optional.ofNullable((Expression) process(node.getWhere().get(), context))
+              : Optional.empty()
+      );
+    } else {
+      return new Delete((Table) process(node.getTable(), context),
+          node.getWhere().isPresent()
+              ? Optional.ofNullable((Expression) process(node.getWhere().get(), context))
+              : Optional.empty()
+      );
+    }
+
+  }
+
+  protected Node visitGroupBy(GroupBy node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new GroupBy(
+          node.getLocation().get(),
+          node.isDistinct(),
+          node.getGroupingElements().stream()
+              .map(groupingElement -> (GroupingElement) process(groupingElement, context))
+              .collect(Collectors.toList())
+      );
+    } else {
+      return new GroupBy(
+          node.isDistinct(),
+          node.getGroupingElements().stream()
+              .map(groupingElement -> (GroupingElement) process(groupingElement, context))
+              .collect(Collectors.toList())
+      );
+    }
+
+  }
+
+  protected Node visitGroupingElement(GroupingElement node, Object context) {
+    return visitNode(node, context);
+  }
+
+  protected Node visitSimpleGroupBy(SimpleGroupBy node, Object context) {
+    if (node.getLocation().isPresent()) {
+      return new SimpleGroupBy(node.getLocation().get(),
+          node.getColumnExpressions().stream()
+              .map(ce -> (Expression) process(ce, context))
+              .collect(Collectors.toList())
+      );
+    } else {
+      return new SimpleGroupBy(node.getColumnExpressions().stream()
+          .map(ce -> (Expression) process(ce, context))
+          .collect(Collectors.toList())
+      );
+    }
+
+  }
+
+  protected Node visitSymbolReference(SymbolReference node, Object context) {
+    return new SymbolReference(node.getName());
+  }
+}

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
@@ -306,6 +306,23 @@ public abstract class AstVisitor<R, C> {
     return visitExpression(node, context);
   }
 
+  protected R visitWindowExpression(WindowExpression node, C context) {
+    return visitNode(node, context);
+  }
+
+  protected R visitTumblingWindowExpression(TumblingWindowExpression node, C context) {
+    return visitNode(node, context);
+  }
+
+  protected R visitHoppingWindowExpression(HoppingWindowExpression node, C context) {
+    return visitNode(node, context);
+  }
+
+  protected R visitSessionWindowExpression(SessionWindowExpression node, C context) {
+    return visitNode(node, context);
+  }
+
+
   protected R visitWindow(Window node, C context) {
     return visitNode(node, context);
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
@@ -33,15 +33,26 @@ public class CreateStreamAsSelect extends Statement implements CreateAsSelect {
   private final Map<String, Expression> properties;
   private final Optional<Expression> partitionByColumn;
 
-  public CreateStreamAsSelect(NodeLocation location, QualifiedName name, Query query,
-                      boolean notExists, Map<String, Expression> properties,
-                              Optional<Expression> partitionByColumn) {
+  public CreateStreamAsSelect(QualifiedName name,
+      Query query,
+      boolean notExists,
+      Map<String, Expression> properties,
+      Optional<Expression> partitionByColumn) {
+    this(Optional.empty(), name, query, notExists, properties, partitionByColumn);
+  }
+
+  public CreateStreamAsSelect(NodeLocation location,
+      QualifiedName name,
+      Query query,
+      boolean notExists,
+      Map<String, Expression> properties,
+      Optional<Expression> partitionByColumn) {
     this(Optional.of(location), name, query, notExists, properties, partitionByColumn);
   }
 
   private CreateStreamAsSelect(Optional<NodeLocation> location, QualifiedName name,
-                               Query query, boolean notExists,
-                       Map<String, Expression> properties, Optional<Expression> partitionByColumn) {
+      Query query, boolean notExists,
+      Map<String, Expression> properties, Optional<Expression> partitionByColumn) {
     super(location);
     this.name = requireNonNull(name, "stream is null");
     this.query = query;
@@ -91,9 +102,9 @@ public class CreateStreamAsSelect extends Statement implements CreateAsSelect {
     }
     CreateStreamAsSelect o = (CreateStreamAsSelect) obj;
     return Objects.equals(name, o.name)
-           && Objects.equals(query, o.query)
-           && Objects.equals(notExists, o.notExists)
-           && Objects.equals(properties, o.properties);
+        && Objects.equals(query, o.query)
+        && Objects.equals(notExists, o.notExists)
+        && Objects.equals(properties, o.properties);
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
@@ -33,26 +33,32 @@ public class CreateStreamAsSelect extends Statement implements CreateAsSelect {
   private final Map<String, Expression> properties;
   private final Optional<Expression> partitionByColumn;
 
-  public CreateStreamAsSelect(QualifiedName name,
-      Query query,
-      boolean notExists,
-      Map<String, Expression> properties,
-      Optional<Expression> partitionByColumn) {
+  public CreateStreamAsSelect(
+      final QualifiedName name,
+      final Query query,
+      final boolean notExists,
+      final Map<String, Expression> properties,
+      final Optional<Expression> partitionByColumn) {
     this(Optional.empty(), name, query, notExists, properties, partitionByColumn);
   }
 
-  public CreateStreamAsSelect(NodeLocation location,
-      QualifiedName name,
-      Query query,
-      boolean notExists,
-      Map<String, Expression> properties,
-      Optional<Expression> partitionByColumn) {
+  public CreateStreamAsSelect(
+      final NodeLocation location,
+      final QualifiedName name,
+      final Query query,
+      final boolean notExists,
+      final Map<String, Expression> properties,
+      final Optional<Expression> partitionByColumn) {
     this(Optional.of(location), name, query, notExists, properties, partitionByColumn);
   }
 
-  private CreateStreamAsSelect(Optional<NodeLocation> location, QualifiedName name,
-      Query query, boolean notExists,
-      Map<String, Expression> properties, Optional<Expression> partitionByColumn) {
+  private CreateStreamAsSelect(
+      final Optional<NodeLocation> location,
+      final QualifiedName name,
+      final Query query,
+      final boolean notExists,
+      final Map<String, Expression> properties,
+      final Optional<Expression> partitionByColumn) {
     super(location);
     this.name = requireNonNull(name, "stream is null");
     this.query = query;

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DefaultAstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DefaultAstVisitor.java
@@ -298,6 +298,22 @@ public abstract class DefaultAstVisitor<R, C>
     return visitExpression(node, context);
   }
 
+  protected R visitWindowExpression(WindowExpression node, C context) {
+    return visitNode(node, context);
+  }
+
+  protected R visitTumblingWindowExpression(TumblingWindowExpression node, C context) {
+    return visitNode(node, context);
+  }
+
+  protected R visitHoppingWindowExpression(HoppingWindowExpression node, C context) {
+    return visitNode(node, context);
+  }
+
+  protected R visitSessionWindowExpression(SessionWindowExpression node, C context) {
+    return visitNode(node, context);
+  }
+
   protected R visitWindow(Window node, C context) {
     return visitNode(node, context);
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DefaultAstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DefaultAstVisitor.java
@@ -350,6 +350,14 @@ public abstract class DefaultAstVisitor<R, C>
     return visitStatement(node, context);
   }
 
+  protected R visitDropTopic(DropTopic node, C context) {
+    return visitStatement(node, context);
+  }
+
+  protected R visitDropStream(DropStream node, C context) {
+    return visitStatement(node, context);
+  }
+
   protected R visitDropTable(DropTable node, C context) {
     return visitStatement(node, context);
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/HoppingWindowExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/HoppingWindowExpression.java
@@ -59,10 +59,31 @@ public class HoppingWindowExpression extends KsqlWindowExpression {
     this.advanceByUnit = advanceByUnit;
   }
 
+  public long getSize() {
+    return size;
+  }
+
+  public TimeUnit getSizeUnit() {
+    return sizeUnit;
+  }
+
+  public long getAdvanceBy() {
+    return advanceBy;
+  }
+
+  public TimeUnit getAdvanceByUnit() {
+    return advanceByUnit;
+  }
+
+  @Override
+  public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+    return visitor.visitHoppingWindowExpression(this, context);
+  }
+
   @Override
   public String toString() {
     return " HOPPING ( SIZE " + size + " " + sizeUnit + " , ADVANCE BY "
-           + advanceBy + " " + "" + advanceByUnit + " ) ";
+        + advanceBy + " " + "" + advanceByUnit + " ) ";
   }
 
   @Override
@@ -80,8 +101,8 @@ public class HoppingWindowExpression extends KsqlWindowExpression {
     }
     HoppingWindowExpression hoppingWindowExpression = (HoppingWindowExpression) o;
     return hoppingWindowExpression.size == size && hoppingWindowExpression.sizeUnit == sizeUnit
-           && hoppingWindowExpression.advanceBy == advanceBy && hoppingWindowExpression
-                                                                    .advanceByUnit == advanceByUnit;
+        && hoppingWindowExpression.advanceBy == advanceBy && hoppingWindowExpression
+        .advanceByUnit == advanceByUnit;
   }
 
   @SuppressWarnings("unchecked")

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SessionWindowExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SessionWindowExpression.java
@@ -39,10 +39,23 @@ public class SessionWindowExpression extends KsqlWindowExpression {
   }
 
   private SessionWindowExpression(Optional<NodeLocation> location, long gap,
-                                  TimeUnit sizeUnit) {
+      TimeUnit sizeUnit) {
     super(location);
     this.gap = gap;
     this.sizeUnit = sizeUnit;
+  }
+
+  public long getGap() {
+    return gap;
+  }
+
+  public TimeUnit getSizeUnit() {
+    return sizeUnit;
+  }
+
+  @Override
+  public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+    return visitor.visitSessionWindowExpression(this, context);
   }
 
   @Override
@@ -70,9 +83,9 @@ public class SessionWindowExpression extends KsqlWindowExpression {
   @SuppressWarnings("unchecked")
   @Override
   public KTable applyAggregate(final KGroupedStream groupedStream,
-                               final Initializer initializer,
-                               final UdafAggregator aggregator,
-                               final Materialized<String, GenericRow, ?> materialized) {
+      final Initializer initializer,
+      final UdafAggregator aggregator,
+      final Materialized<String, GenericRow, ?> materialized) {
     return groupedStream.windowedBy(SessionWindows.with(sizeUnit.toMillis(gap)))
         .aggregate(initializer, aggregator, aggregator.getMerger(),
             materialized);

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SimpleGroupBy.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SimpleGroupBy.java
@@ -35,12 +35,16 @@ public class SimpleGroupBy
 
   private final List<Expression> columns;
 
+  public SimpleGroupBy(List<Expression> simpleGroupByExpressions) {
+    this(Optional.empty(), simpleGroupByExpressions);
+  }
+
   public SimpleGroupBy(NodeLocation location, List<Expression> simpleGroupByExpressions) {
     this(Optional.of(location), simpleGroupByExpressions);
   }
 
   private SimpleGroupBy(Optional<NodeLocation> location,
-                        List<Expression> simpleGroupByExpressions) {
+      List<Expression> simpleGroupByExpressions) {
     super(location);
     this.columns = requireNonNull(simpleGroupByExpressions);
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Table.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Table.java
@@ -44,6 +44,21 @@ public class Table
     this(Optional.of(location), name, isStdOut);
   }
 
+  public Table(NodeLocation location,
+      QualifiedName name,
+      boolean isStdOut,
+      Map<String, Expression> properties) {
+    this(Optional.ofNullable(location), name, isStdOut);
+    this.setProperties(properties);
+  }
+
+  public Table(QualifiedName name,
+      boolean isStdOut,
+      Map<String, Expression> properties) {
+    this(Optional.empty(), name, isStdOut);
+    this.setProperties(properties);
+  }
+
   private Table(Optional<NodeLocation> location, QualifiedName name, boolean isStdOut) {
     super(location);
     this.name = name;

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Table.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Table.java
@@ -28,38 +28,43 @@ public class Table
   private final Map<String, Expression> properties  = new HashMap<>();
   private final QualifiedName name;
 
-  public Table(QualifiedName name) {
+  public Table(final QualifiedName name) {
     this(Optional.empty(), name, false);
   }
 
-  public Table(QualifiedName name, boolean isStdOut) {
+  public Table(final QualifiedName name, final boolean isStdOut) {
     this(Optional.empty(), name, isStdOut);
   }
 
-  public Table(NodeLocation location, QualifiedName name) {
+  public Table(final NodeLocation location, final QualifiedName name) {
     this(Optional.of(location), name, false);
   }
 
-  public Table(NodeLocation location, QualifiedName name, boolean isStdOut) {
+  public Table(final NodeLocation location, final QualifiedName name, final boolean isStdOut) {
     this(Optional.of(location), name, isStdOut);
   }
 
-  public Table(NodeLocation location,
-      QualifiedName name,
-      boolean isStdOut,
-      Map<String, Expression> properties) {
+  public Table(
+      final NodeLocation location,
+      final QualifiedName name,
+      final boolean isStdOut,
+      final Map<String, Expression> properties) {
     this(Optional.ofNullable(location), name, isStdOut);
     this.setProperties(properties);
   }
 
-  public Table(QualifiedName name,
-      boolean isStdOut,
-      Map<String, Expression> properties) {
+  public Table(
+      final QualifiedName name,
+      final boolean isStdOut,
+      final  Map<String, Expression> properties) {
     this(Optional.empty(), name, isStdOut);
     this.setProperties(properties);
   }
 
-  private Table(Optional<NodeLocation> location, QualifiedName name, boolean isStdOut) {
+  private Table(
+      final Optional<NodeLocation> location,
+      final QualifiedName name,
+      final boolean isStdOut) {
     super(location);
     this.name = name;
     this.isStdOut = isStdOut;

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TumblingWindowExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TumblingWindowExpression.java
@@ -39,10 +39,23 @@ public class TumblingWindowExpression extends KsqlWindowExpression {
   }
 
   private TumblingWindowExpression(Optional<NodeLocation> location, long size,
-                                   TimeUnit sizeUnit) {
+      TimeUnit sizeUnit) {
     super(location);
     this.size = size;
     this.sizeUnit = sizeUnit;
+  }
+
+  public long getSize() {
+    return size;
+  }
+
+  public TimeUnit getSizeUnit() {
+    return sizeUnit;
+  }
+
+  @Override
+  public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+    return visitor.visitTumblingWindowExpression(this, context);
   }
 
   @Override
@@ -70,9 +83,9 @@ public class TumblingWindowExpression extends KsqlWindowExpression {
   @SuppressWarnings("unchecked")
   @Override
   public KTable applyAggregate(final KGroupedStream groupedStream,
-                               final Initializer initializer,
-                               final UdafAggregator aggregator,
-                               final Materialized<String, GenericRow, ?> materialized) {
+      final Initializer initializer,
+      final UdafAggregator aggregator,
+      final Materialized<String, GenericRow, ?> materialized) {
     return groupedStream.windowedBy(TimeWindows.of(sizeUnit.toMillis(size)))
         .aggregate(initializer, aggregator, materialized);
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Window.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Window.java
@@ -26,6 +26,7 @@ public class Window
 
 
   private final WindowExpression windowExpression;
+  private final String windowName;
 
   public Window(String windowName, WindowExpression windowExpression) {
     this(Optional.empty(), windowName, windowExpression);
@@ -36,13 +37,18 @@ public class Window
   }
 
   private Window(Optional<NodeLocation> location, String windowName,
-                 WindowExpression windowExpression) {
+      WindowExpression windowExpression) {
     super(location);
+    this.windowName = windowName;
     this.windowExpression = requireNonNull(windowExpression, "windowExpression is null");
   }
 
   public WindowExpression getWindowExpression() {
     return windowExpression;
+  }
+
+  public String getWindowName() {
+    return windowName;
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WindowExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WindowExpression.java
@@ -29,15 +29,29 @@ public class WindowExpression extends Node {
     this(Optional.empty(), windowName, ksqlWindowExpression);
   }
 
+  public WindowExpression(NodeLocation location, String windowName,
+      KsqlWindowExpression ksqlWindowExpression) {
+    this(Optional.of(location), windowName, ksqlWindowExpression);
+  }
+
   protected WindowExpression(Optional<NodeLocation> location, String windowName,
-                             KsqlWindowExpression ksqlWindowExpression) {
+      KsqlWindowExpression ksqlWindowExpression) {
     super(location);
     this.windowName = windowName;
     this.ksqlWindowExpression = ksqlWindowExpression;
   }
 
+  public String getWindowName() {
+    return windowName;
+  }
+
   public KsqlWindowExpression getKsqlWindowExpression() {
     return ksqlWindowExpression;
+  }
+
+  @Override
+  public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+    return visitor.visitWindowExpression(this, context);
   }
 
   @Override

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
@@ -68,16 +68,16 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    assertThat("testSimpleQuery fails", rewrittenStatement, instanceOf(Query.class));
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testSimpleQuery fails", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testSimpleQuery fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
-    Assert.assertTrue("testSimpleQuery fails", querySpecification.getSelect().getSelectItems().size() == 3);
+    assertThat("testSimpleQuery fails", querySpecification.getSelect().getSelectItems().size() == 3);
     assertThat(querySpecification.getFrom(), not(nullValue()));
-    Assert.assertTrue("testSimpleQuery fails", querySpecification.getWhere().isPresent());
-    Assert.assertTrue("testSimpleQuery fails", querySpecification.getWhere().get() instanceof ComparisonExpression);
+    assertThat("testSimpleQuery fails", querySpecification.getWhere().isPresent());
+    assertThat("testSimpleQuery fails", querySpecification.getWhere().get() instanceof ComparisonExpression);
     ComparisonExpression comparisonExpression = (ComparisonExpression)querySpecification.getWhere().get();
-    Assert.assertTrue("testSimpleQuery fails", comparisonExpression.getType().getValue().equalsIgnoreCase(">"));
+    assertThat("testSimpleQuery fails", comparisonExpression.getType().getValue(), equalTo(">"));
 
   }
 
@@ -89,16 +89,16 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    assertThat("testSimpleQuery fails", rewrittenStatement, instanceOf(Query.class));
 
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testProjection fails", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testProjection fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
-    Assert.assertTrue("testProjection fails", querySpecification.getSelect().getSelectItems().size() == 3);
-    Assert.assertTrue("testProjection fails", querySpecification.getSelect().getSelectItems().get(0) instanceof SingleColumn);
+    assertThat("testProjection fails", querySpecification.getSelect().getSelectItems().size() , equalTo(3));
+    assertThat("testProjection fails", querySpecification.getSelect().getSelectItems().get(0), instanceOf(SingleColumn.class));
     SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    Assert.assertTrue("testProjection fails", column0.getAlias().get().equalsIgnoreCase("COL0"));
-    Assert.assertTrue("testProjection fails", column0.getExpression().toString().equalsIgnoreCase("TEST1.COL0"));
+    assertThat("testProjection fails", column0.getAlias().get(), equalTo("COL0"));
+    assertThat("testProjection fails", column0.getExpression().toString(), equalTo("TEST1.COL0"));
   }
 
   @Test
@@ -109,24 +109,22 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    assertThat("testSimpleQuery fails", rewrittenStatement, instanceOf(Query.class));
 
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testProjectionWithArrayMap fails", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testProjectionWithArrayMap fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
-    Assert.assertTrue("testProjectionWithArrayMap fails", querySpecification.getSelect().getSelectItems()
-        .size() == 5);
-    Assert.assertTrue("testProjectionWithArrayMap fails", querySpecification.getSelect().getSelectItems().get(0) instanceof SingleColumn);
+    assertThat("testProjectionWithArrayMap fails", querySpecification.getSelect().getSelectItems()
+        .size(), equalTo(5));
+    assertThat("testProjectionWithArrayMap fails", querySpecification.getSelect().getSelectItems().get(0) instanceof SingleColumn);
     SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    Assert.assertTrue("testProjectionWithArrayMap fails", column0.getAlias().get().equalsIgnoreCase("COL0"));
-    Assert.assertTrue("testProjectionWithArrayMap fails", column0.getExpression().toString().equalsIgnoreCase("TEST1.COL0"));
+    assertThat("testProjectionWithArrayMap fails", column0.getAlias().get(), equalTo("COL0"));
+    assertThat("testProjectionWithArrayMap fails", column0.getExpression().toString(), equalTo("TEST1.COL0"));
 
     SingleColumn column3 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(3);
     SingleColumn column4 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(4);
-    Assert.assertTrue("testProjectionWithArrayMap fails", column3.getExpression().toString()
-        .equalsIgnoreCase("TEST1.COL4[0]"));
-    Assert.assertTrue("testProjectionWithArrayMap fails", column4.getExpression().toString()
-        .equalsIgnoreCase("TEST1.COL5['key1']"));
+    assertThat("testProjectionWithArrayMap fails", column3.getExpression().toString(), equalTo("TEST1.COL4[0]"));
+    assertThat("testProjectionWithArrayMap fails", column4.getExpression().toString(), equalTo("TEST1.COL5['key1']"));
   }
 
   @Test
@@ -136,16 +134,16 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    assertThat("testSimpleQuery fails", rewrittenStatement, instanceOf(Query.class));
 
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testProjectFilter fails", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testProjectFilter fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
 
-    Assert.assertTrue("testProjectFilter fails", querySpecification.getWhere().get() instanceof ComparisonExpression);
+    assertThat("testProjectFilter fails", querySpecification.getWhere().get(), instanceOf(ComparisonExpression.class));
     ComparisonExpression comparisonExpression = (ComparisonExpression)querySpecification.getWhere().get();
-    Assert.assertTrue("testProjectFilter fails", comparisonExpression.toString().equalsIgnoreCase("(TEST1.COL0 > 100)"));
-    Assert.assertTrue("testProjectFilter fails", querySpecification.getSelect().getSelectItems().size() == 3);
+    assertThat("testProjectFilter fails", comparisonExpression.toString(), equalTo("(TEST1.COL0 > 100)"));
+    assertThat("testProjectFilter fails", querySpecification.getSelect().getSelectItems().size(), equalTo(3));
 
   }
 
@@ -156,14 +154,14 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    assertThat("testSimpleQuery fails", rewrittenStatement, instanceOf(Query.class));
 
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testBinaryExpression fails", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testBinaryExpression fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
     SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    Assert.assertTrue("testBinaryExpression fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
-    Assert.assertTrue("testBinaryExpression fails", column0.getExpression().toString().equalsIgnoreCase("(TEST1.COL0 + 10)"));
+    assertThat("testBinaryExpression fails", column0.getAlias().get(), equalTo("KSQL_COL_0"));
+    assertThat("testBinaryExpression fails", column0.getExpression().toString(), equalTo("(TEST1.COL0 + 10)"));
   }
 
   @Test
@@ -173,14 +171,14 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    assertThat("testSimpleQuery fails", rewrittenStatement, instanceOf(Query.class));
 
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testProjection fails", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testProjection fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
     SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    Assert.assertTrue("testBooleanExpression fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
-    Assert.assertTrue("testBooleanExpression fails", column0.getExpression().toString().equalsIgnoreCase("(TEST1.COL0 = 10)"));
+    assertThat("testBooleanExpression fails", column0.getAlias().get(), equalTo("KSQL_COL_0"));
+    assertThat("testBooleanExpression fails", column0.getExpression().toString(), equalTo("(TEST1.COL0 = 10)"));
   }
 
   @Test
@@ -190,34 +188,34 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    assertThat("testSimpleQuery fails", rewrittenStatement, instanceOf(Query.class));
 
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testLiterals fails", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testLiterals fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
     SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    Assert.assertTrue("testLiterals fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
-    Assert.assertTrue("testLiterals fails", column0.getExpression().toString().equalsIgnoreCase("10"));
+    assertThat("testLiterals fails", column0.getAlias().get(), equalTo("KSQL_COL_0"));
+    assertThat("testLiterals fails", column0.getExpression().toString(), equalTo("10"));
 
     SingleColumn column1 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(1);
-    Assert.assertTrue("testLiterals fails", column1.getAlias().get().equalsIgnoreCase("COL2"));
-    Assert.assertTrue("testLiterals fails", column1.getExpression().toString().equalsIgnoreCase("TEST1.COL2"));
+    assertThat("testLiterals fails", column1.getAlias().get(), equalTo("COL2"));
+    assertThat("testLiterals fails", column1.getExpression().toString(), equalTo("TEST1.COL2"));
 
     SingleColumn column2 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(2);
-    Assert.assertTrue("testLiterals fails", column2.getAlias().get().equalsIgnoreCase("KSQL_COL_2"));
-    Assert.assertTrue("testLiterals fails", column2.getExpression().toString().equalsIgnoreCase("'test'"));
+    assertThat("testLiterals fails", column2.getAlias().get(), equalTo("KSQL_COL_2"));
+    assertThat("testLiterals fails", column2.getExpression().toString(), equalTo("'test'"));
 
     SingleColumn column3 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(3);
-    Assert.assertTrue("testLiterals fails", column3.getAlias().get().equalsIgnoreCase("KSQL_COL_3"));
-    Assert.assertTrue("testLiterals fails", column3.getExpression().toString().equalsIgnoreCase("2.5"));
+    assertThat("testLiterals fails", column3.getAlias().get(), equalTo("KSQL_COL_3"));
+    assertThat("testLiterals fails", column3.getExpression().toString(), equalTo("2.5"));
 
     SingleColumn column4 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(4);
-    Assert.assertTrue("testLiterals fails", column4.getAlias().get().equalsIgnoreCase("KSQL_COL_4"));
-    Assert.assertTrue("testLiterals fails", column4.getExpression().toString().equalsIgnoreCase("true"));
+    assertThat("testLiterals fails", column4.getAlias().get(), equalTo("KSQL_COL_4"));
+    assertThat("testLiterals fails", column4.getExpression().toString(), equalTo("true"));
 
     SingleColumn column5 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(5);
-    Assert.assertTrue("testLiterals fails", column5.getAlias().get().equalsIgnoreCase("KSQL_COL_5"));
-    Assert.assertTrue("testLiterals fails", column5.getExpression().toString().equalsIgnoreCase("-5"));
+    assertThat("testLiterals fails", column5.getAlias().get(), equalTo("KSQL_COL_5"));
+    assertThat("testLiterals fails", column5.getExpression().toString(), equalTo("-5"));
   }
 
   @Test
@@ -229,22 +227,22 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    assertThat("testSimpleQuery fails", rewrittenStatement, instanceOf(Query.class));
 
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testProjection fails", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testProjection fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
     SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    Assert.assertTrue("testProjection fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
-    Assert.assertTrue("testProjection fails", column0.getExpression().toString().equalsIgnoreCase("10"));
+    assertThat("testProjection fails", column0.getAlias().get(), equalTo("KSQL_COL_0"));
+    assertThat("testProjection fails", column0.getExpression().toString(), equalTo("10"));
 
     SingleColumn column1 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(1);
-    Assert.assertTrue("testProjection fails", column1.getAlias().get().equalsIgnoreCase("COL2"));
-    Assert.assertTrue("testProjection fails", column1.getExpression().toString().equalsIgnoreCase("TEST1.COL2"));
+    assertThat("testProjection fails", column1.getAlias().get(), equalTo("COL2"));
+    assertThat("testProjection fails", column1.getExpression().toString(), equalTo("TEST1.COL2"));
 
     SingleColumn column2 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(2);
-    Assert.assertTrue("testProjection fails", column2.getAlias().get().equalsIgnoreCase("KSQL_COL_2"));
-    Assert.assertTrue("testProjection fails", column2.getExpression().toString().equalsIgnoreCase("'test'"));
+    assertThat("testProjection fails", column2.getAlias().get(), equalTo("KSQL_COL_2"));
+    assertThat("testProjection fails", column2.getExpression().toString(), equalTo("'test'"));
 
   }
 
@@ -258,17 +256,17 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    assertThat("testSimpleQuery fails", rewrittenStatement, instanceOf(Query.class));
 
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testSimpleLeftJoin fails", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testSimpleLeftJoin fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
-    Assert.assertTrue("testSimpleLeftJoin fails", querySpecification.getFrom() instanceof Join);
+    assertThat("testSimpleLeftJoin fails", querySpecification.getFrom() instanceof Join);
     Join join = (Join) querySpecification.getFrom();
-    Assert.assertTrue("testSimpleLeftJoin fails", join.getType().toString().equalsIgnoreCase("LEFT"));
+    assertThat("testSimpleLeftJoin fails", join.getType().toString(), equalTo("LEFT"));
 
-    Assert.assertTrue("testSimpleLeftJoin fails", ((AliasedRelation)join.getLeft()).getAlias().equalsIgnoreCase("T1"));
-    Assert.assertTrue("testSimpleLeftJoin fails", ((AliasedRelation)join.getRight()).getAlias().equalsIgnoreCase("T2"));
+    assertThat("testSimpleLeftJoin fails", ((AliasedRelation)join.getLeft()).getAlias(), equalTo("T1"));
+    assertThat("testSimpleLeftJoin fails", ((AliasedRelation)join.getRight()).getAlias(), equalTo("T2"));
 
   }
 
@@ -282,19 +280,19 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    assertThat("testSimpleQuery fails", rewrittenStatement, instanceOf(Query.class));
 
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testLeftJoinWithFilter fails", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testLeftJoinWithFilter fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
-    Assert.assertTrue("testLeftJoinWithFilter fails", querySpecification.getFrom() instanceof Join);
+    assertThat("testLeftJoinWithFilter fails", querySpecification.getFrom() instanceof Join);
     Join join = (Join) querySpecification.getFrom();
-    Assert.assertTrue("testLeftJoinWithFilter fails", join.getType().toString().equalsIgnoreCase("LEFT"));
+    assertThat("testLeftJoinWithFilter fails", join.getType().toString(), equalTo("LEFT"));
 
-    Assert.assertTrue("testLeftJoinWithFilter fails", ((AliasedRelation)join.getLeft()).getAlias().equalsIgnoreCase("T1"));
-    Assert.assertTrue("testLeftJoinWithFilter fails", ((AliasedRelation)join.getRight()).getAlias().equalsIgnoreCase("T2"));
+    assertThat("testLeftJoinWithFilter fails", ((AliasedRelation)join.getLeft()).getAlias(), equalTo("T1"));
+    assertThat("testLeftJoinWithFilter fails", ((AliasedRelation)join.getRight()).getAlias(), equalTo("T2"));
 
-    Assert.assertTrue("testLeftJoinWithFilter fails", querySpecification.getWhere().get().toString().equalsIgnoreCase("(T2.COL2 = 'test')"));
+    assertThat("testLeftJoinWithFilter fails", querySpecification.getWhere().get().toString(), equalTo("(T2.COL2 = 'test')"));
   }
 
   @Test
@@ -304,12 +302,12 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    assertThat("testSimpleQuery fails", rewrittenStatement, instanceOf(Query.class));
 
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testSelectAll fails", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testSelectAll fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
-    Assert.assertTrue("testSelectAll fails", querySpecification.getSelect().getSelectItems()
+    assertThat("testSelectAll fails", querySpecification.getSelect().getSelectItems()
         .size() == 8);
   }
 
@@ -322,17 +320,17 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    assertThat("testSimpleQuery fails", rewrittenStatement, instanceOf(Query.class));
 
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testLeftJoinWithFilter fails", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testLeftJoinWithFilter fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
-    Assert.assertTrue("testSelectAllJoin fails", querySpecification.getFrom() instanceof Join);
+    assertThat("testSelectAllJoin fails", querySpecification.getFrom() instanceof Join);
     Join join = (Join) querySpecification.getFrom();
-    Assert.assertTrue("testSelectAllJoin fails", querySpecification.getSelect().getSelectItems
+    assertThat("testSelectAllJoin fails", querySpecification.getSelect().getSelectItems
         ().size() == 15);
-    Assert.assertTrue("testLeftJoinWithFilter fails", ((AliasedRelation)join.getLeft()).getAlias().equalsIgnoreCase("T1"));
-    Assert.assertTrue("testLeftJoinWithFilter fails", ((AliasedRelation)join.getRight()).getAlias().equalsIgnoreCase("T2"));
+    assertThat("testLeftJoinWithFilter fails", ((AliasedRelation)join.getLeft()).getAlias(), equalTo("T1"));
+    assertThat("testLeftJoinWithFilter fails", ((AliasedRelation)join.getRight()).getAlias(), equalTo("T2"));
   }
 
   @Test
@@ -342,23 +340,23 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    assertThat("testSimpleQuery fails", rewrittenStatement, instanceOf(Query.class));
 
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testSelectAll fails", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testSelectAll fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
 
     SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    Assert.assertTrue("testProjection fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
-    Assert.assertTrue("testProjection fails", column0.getExpression().toString().equalsIgnoreCase("LCASE(T1.COL1)"));
+    assertThat("testProjection fails", column0.getAlias().get(), equalTo("KSQL_COL_0"));
+    assertThat("testProjection fails", column0.getExpression().toString(), equalTo("LCASE(T1.COL1)"));
 
     SingleColumn column1 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(1);
-    Assert.assertTrue("testProjection fails", column1.getAlias().get().equalsIgnoreCase("KSQL_COL_1"));
-    Assert.assertTrue("testProjection fails", column1.getExpression().toString().equalsIgnoreCase("CONCAT(T1.COL2, 'hello')"));
+    assertThat("testProjection fails", column1.getAlias().get(), equalTo("KSQL_COL_1"));
+    assertThat("testProjection fails", column1.getExpression().toString(), equalTo("CONCAT(T1.COL2, 'hello')"));
 
     SingleColumn column2 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(2);
-    Assert.assertTrue("testProjection fails", column2.getAlias().get().equalsIgnoreCase("KSQL_COL_2"));
-    Assert.assertTrue("testProjection fails", column2.getExpression().toString().equalsIgnoreCase("FLOOR(ABS(T1.COL3))"));
+    assertThat("testProjection fails", column2.getAlias().get(), equalTo("KSQL_COL_2"));
+    assertThat("testProjection fails", column2.getExpression().toString(), equalTo("FLOOR(ABS(T1.COL3))"));
   }
 
   @Test
@@ -372,12 +370,12 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testCreateStream failed.", rewrittenStatement instanceof CreateStream);
+    assertThat("testCreateStream failed.", rewrittenStatement instanceof CreateStream);
     CreateStream createStream = (CreateStream)rewrittenStatement;
-    Assert.assertTrue("testCreateStream failed.", createStream.getName().toString().equalsIgnoreCase("ORDERS"));
-    Assert.assertTrue("testCreateStream failed.", createStream.getElements().size() == 4);
-    Assert.assertTrue("testCreateStream failed.", createStream.getElements().get(0).getName().toString().equalsIgnoreCase("ordertime"));
-    Assert.assertTrue("testCreateStream failed.", createStream.getProperties().get(DdlConfig.TOPIC_NAME_PROPERTY).toString().equalsIgnoreCase("'orders_topic'"));
+    assertThat("testCreateStream failed.", createStream.getName().toString(), equalTo("ORDERS"));
+    assertThat("testCreateStream failed.", createStream.getElements().size() == 4);
+    assertThat("testCreateStream failed.", createStream.getElements().get(0).getName().toString(), equalTo("ORDERTIME"));
+    assertThat("testCreateStream failed.", createStream.getProperties().get(DdlConfig.TOPIC_NAME_PROPERTY).toString(), equalTo("'orders_topic'"));
   }
 
   @Test
@@ -392,7 +390,7 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testCreateStream failed.", rewrittenStatement instanceof CreateStream);
+    assertThat("testCreateStream failed.", rewrittenStatement instanceof CreateStream);
     CreateStream createStream = (CreateStream)rewrittenStatement;
     assertThat(createStream.getName().toString().toUpperCase(), equalTo("ORDERS"));
     assertThat(createStream.getElements().size(), equalTo(7));
@@ -416,16 +414,16 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testCreateStream failed.", rewrittenStatement instanceof CreateStream);
+    assertThat("testCreateStream failed.", rewrittenStatement instanceof CreateStream);
     CreateStream createStream = (CreateStream)rewrittenStatement;
 
-    Assert.assertTrue("testCreateStream failed.", createStream.getName().toString().equalsIgnoreCase("ORDERS"));
-    Assert.assertTrue("testCreateStream failed.", createStream.getElements().size() == 4);
-    Assert.assertTrue("testCreateStream failed.", createStream.getElements().get(0).getName().toString().equalsIgnoreCase("ordertime"));
-    Assert.assertTrue("testCreateStream failed.", createStream.getProperties().get(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY).toString().equalsIgnoreCase("'orders_topic'"));
-    Assert.assertTrue("testCreateStream failed.", createStream.getProperties().get(DdlConfig
-        .VALUE_FORMAT_PROPERTY).toString().equalsIgnoreCase("'avro'"));
-    Assert.assertTrue("testCreateStream failed.", createStream.getProperties().get(DdlConfig.AVRO_SCHEMA_FILE).toString().equalsIgnoreCase("'/Users/hojjat/avro_order_schema.avro'"));
+    assertThat("testCreateStream failed.", createStream.getName().toString(), equalTo("ORDERS"));
+    assertThat("testCreateStream failed.", createStream.getElements().size() == 4);
+    assertThat("testCreateStream failed.", createStream.getElements().get(0).getName().toString(), equalTo("ORDERTIME"));
+    assertThat("testCreateStream failed.", createStream.getProperties().get(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY).toString(), equalTo("'orders_topic'"));
+    assertThat("testCreateStream failed.", createStream.getProperties().get(DdlConfig
+        .VALUE_FORMAT_PROPERTY).toString(), equalTo("'avro'"));
+    assertThat("testCreateStream failed.", createStream.getProperties().get(DdlConfig.AVRO_SCHEMA_FILE).toString(), equalTo("'/Users/hojjat/avro_order_schema.avro'"));
   }
 
   @Test
@@ -436,12 +434,12 @@ public class StatementRewriterTest {
     Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
-    Assert.assertTrue("testRegisterTopic failed.", rewrittenStatement instanceof CreateTable);
+    assertThat("testRegisterTopic failed.", rewrittenStatement instanceof CreateTable);
     CreateTable createTable = (CreateTable)rewrittenStatement;
-    Assert.assertTrue("testCreateTable failed.", createTable.getName().toString().equalsIgnoreCase("USERS"));
-    Assert.assertTrue("testCreateTable failed.", createTable.getElements().size() == 4);
-    Assert.assertTrue("testCreateTable failed.", createTable.getElements().get(0).getName().toString().equalsIgnoreCase("usertime"));
-    Assert.assertTrue("testCreateTable failed.", createTable.getProperties().get(DdlConfig.TOPIC_NAME_PROPERTY).toString().equalsIgnoreCase("'users_topic'"));
+    assertThat("testCreateTable failed.", createTable.getName().toString(), equalTo("USERS"));
+    assertThat("testCreateTable failed.", createTable.getElements().size() == 4);
+    assertThat("testCreateTable failed.", createTable.getElements().get(0).getName().toString(), equalTo("USERTIME"));
+    assertThat("testCreateTable failed.", createTable.getProperties().get(DdlConfig.TOPIC_NAME_PROPERTY).toString(), equalTo("'users_topic'"));
   }
 
   @Test
@@ -453,15 +451,15 @@ public class StatementRewriterTest {
     Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
-    Assert.assertTrue("testRegisterTopic failed.", rewrittenStatement instanceof CreateTable);
+    assertThat("testRegisterTopic failed.", rewrittenStatement instanceof CreateTable);
     CreateTable createTable = (CreateTable)rewrittenStatement;
-    Assert.assertTrue("testCreateTable failed.", createTable.getName().toString().equalsIgnoreCase("USERS"));
-    Assert.assertTrue("testCreateTable failed.", createTable.getElements().size() == 4);
-    Assert.assertTrue("testCreateTable failed.", createTable.getElements().get(0).getName().toString().equalsIgnoreCase("usertime"));
-    Assert.assertTrue("testCreateTable failed.", createTable.getProperties().get(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY)
-        .toString().equalsIgnoreCase("'users_topic'"));
-    Assert.assertTrue("testCreateTable failed.", createTable.getProperties().get(DdlConfig.VALUE_FORMAT_PROPERTY)
-        .toString().equalsIgnoreCase("'json'"));
+    assertThat("testCreateTable failed.", createTable.getName().toString(), equalTo("USERS"));
+    assertThat("testCreateTable failed.", createTable.getElements().size() == 4);
+    assertThat("testCreateTable failed.", createTable.getElements().get(0).getName().toString(), equalTo("USERTIME"));
+    assertThat("testCreateTable failed.", createTable.getProperties().get(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY)
+        .toString(), equalTo("'users_topic'"));
+    assertThat("testCreateTable failed.", createTable.getProperties().get(DdlConfig.VALUE_FORMAT_PROPERTY)
+        .toString(), equalTo("'json'"));
   }
 
   @Test
@@ -476,14 +474,14 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testCreateStreamAsSelect failed.", rewrittenStatement instanceof CreateStreamAsSelect);
+    assertThat("testCreateStreamAsSelect failed.", rewrittenStatement instanceof CreateStreamAsSelect);
     CreateStreamAsSelect createStreamAsSelect = (CreateStreamAsSelect)rewrittenStatement;
-    Assert.assertTrue("testCreateTable failed.", createStreamAsSelect.getName().toString().equalsIgnoreCase("bigorders_json"));
-    Assert.assertTrue("testCreateTable failed.", createStreamAsSelect.getQuery().getQueryBody() instanceof QuerySpecification);
+    assertThat("testCreateTable failed.", createStreamAsSelect.getName().toString(), equalTo("BIGORDERS_JSON"));
+    assertThat("testCreateTable failed.", createStreamAsSelect.getQuery().getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification) createStreamAsSelect.getQuery().getQueryBody();
-    Assert.assertTrue("testCreateTable failed.", querySpecification.getSelect().getSelectItems().size() == 4);
-    Assert.assertTrue("testCreateTable failed.", querySpecification.getWhere().get().toString().equalsIgnoreCase("(ORDERS.ORDERUNITS > 5)"));
-    Assert.assertTrue("testCreateTable failed.", ((AliasedRelation)querySpecification.getFrom()).getAlias().equalsIgnoreCase("ORDERS"));
+    assertThat("testCreateTable failed.", querySpecification.getSelect().getSelectItems().size() == 4);
+    assertThat("testCreateTable failed.", querySpecification.getWhere().get().toString(), equalTo("(ORDERS.ORDERUNITS > 5)"));
+    assertThat("testCreateTable failed.", ((AliasedRelation)querySpecification.getFrom()).getAlias(), equalTo("ORDERS"));
   }
 
 
@@ -498,18 +496,18 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSelectTumblingWindow failed.", rewrittenStatement instanceof Query);
+    assertThat("testSelectTumblingWindow failed.", rewrittenStatement, instanceOf(Query.class));
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testSelectTumblingWindow failed.", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testSelectTumblingWindow failed.", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification) query.getQueryBody();
-    Assert.assertTrue("testCreateTable failed.", querySpecification.getSelect().getSelectItems
+    assertThat("testCreateTable failed.", querySpecification.getSelect().getSelectItems
         ().size() == 2);
-    Assert.assertTrue("testSelectTumblingWindow failed.", querySpecification.getWhere().get().toString().equalsIgnoreCase("(ORDERS.ORDERUNITS > 5)"));
-    Assert.assertTrue("testSelectTumblingWindow failed.", ((AliasedRelation)querySpecification.getFrom()).getAlias().equalsIgnoreCase("ORDERS"));
-    Assert.assertTrue("testSelectTumblingWindow failed.", querySpecification
+    assertThat("testSelectTumblingWindow failed.", querySpecification.getWhere().get().toString(), equalTo("(ORDERS.ORDERUNITS > 5)"));
+    assertThat("testSelectTumblingWindow failed.", ((AliasedRelation)querySpecification.getFrom()).getAlias(), equalTo("ORDERS"));
+    assertThat("testSelectTumblingWindow failed.", querySpecification
         .getWindowExpression().isPresent());
-    Assert.assertTrue("testSelectTumblingWindow failed.", querySpecification
-        .getWindowExpression().get().toString().equalsIgnoreCase(" WINDOW STREAMWINDOW  TUMBLING ( SIZE 30 SECONDS ) "));
+    assertThat("testSelectTumblingWindow failed.", querySpecification
+        .getWindowExpression().get().toString(), equalTo(" WINDOW STREAMWINDOW  TUMBLING ( SIZE 30 SECONDS ) "));
   }
 
   @Test
@@ -534,7 +532,7 @@ public class StatementRewriterTest {
     assertThat(querySpecification.getSelect().getSelectItems().size(), equalTo(2));
     assertThat(querySpecification.getWhere().get().toString(), equalTo("(ORDERS.ORDERUNITS > 5)"));
     assertThat(((AliasedRelation)querySpecification.getFrom()).getAlias().toUpperCase(), equalTo("ORDERS"));
-    Assert.assertTrue("window expression isn't present", querySpecification
+    assertThat("window expression isn't present", querySpecification
         .getWindowExpression().isPresent());
     assertThat(querySpecification.getWindowExpression().get().toString().toUpperCase(),
         equalTo(" WINDOW STREAMWINDOW  HOPPING ( SIZE 30 SECONDS , ADVANCE BY 5 SECONDS ) "));
@@ -557,18 +555,18 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSelectSessionWindow failed.", rewrittenStatement instanceof Query);
+    assertThat("testSelectSessionWindow failed.", rewrittenStatement, instanceOf(Query.class));
     Query query = (Query) rewrittenStatement;
-    Assert.assertTrue("testSelectSessionWindow failed.", query.getQueryBody() instanceof QuerySpecification);
+    assertThat("testSelectSessionWindow failed.", query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification) query.getQueryBody();
-    Assert.assertTrue("testCreateTable failed.", querySpecification.getSelect().getSelectItems
+    assertThat("testCreateTable failed.", querySpecification.getSelect().getSelectItems
         ().size() == 2);
-    Assert.assertTrue("testSelectSessionWindow failed.", querySpecification.getWhere().get().toString().equalsIgnoreCase("(ORDERS.ORDERUNITS > 5)"));
-    Assert.assertTrue("testSelectSessionWindow failed.", ((AliasedRelation)querySpecification.getFrom()).getAlias().equalsIgnoreCase("ORDERS"));
-    Assert.assertTrue("testSelectSessionWindow failed.", querySpecification
+    assertThat("testSelectSessionWindow failed.", querySpecification.getWhere().get().toString(), equalTo("(ORDERS.ORDERUNITS > 5)"));
+    assertThat("testSelectSessionWindow failed.", ((AliasedRelation)querySpecification.getFrom()).getAlias(), equalTo("ORDERS"));
+    assertThat("testSelectSessionWindow failed.", querySpecification
         .getWindowExpression().isPresent());
-    Assert.assertTrue("testSelectSessionWindow failed.", querySpecification
-        .getWindowExpression().get().toString().equalsIgnoreCase(" WINDOW STREAMWINDOW  SESSION "
+    assertThat("testSelectSessionWindow failed.", querySpecification
+        .getWindowExpression().get().toString(), equalTo(" WINDOW STREAMWINDOW  SESSION "
             + "( 30 SECONDS ) "));
   }
 
@@ -584,13 +582,13 @@ public class StatementRewriterTest {
     StatementRewriter statementRewriter = new StatementRewriter();
     Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
 
-    Assert.assertTrue("testSelectTumblingWindow failed.", rewrittenStatement instanceof CreateStreamAsSelect);
+    assertThat("testSelectTumblingWindow failed.", rewrittenStatement instanceof CreateStreamAsSelect);
     CreateStreamAsSelect createStreamAsSelect = (CreateStreamAsSelect) rewrittenStatement;
-    Assert.assertTrue("testSelectTumblingWindow failed.", createStreamAsSelect.getQuery().getQueryBody()
-        instanceof QuerySpecification);
+    assertThat("testSelectTumblingWindow failed.", createStreamAsSelect.getQuery().getQueryBody()
+       , instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification)
         createStreamAsSelect.getQuery().getQueryBody();
-    Assert.assertTrue(querySpecification.getWhere().toString().equalsIgnoreCase("Optional[(((ORDERS.COL2 IS NULL) AND (ORDERS.COL3 IS NOT NULL)) OR ((ORDERS.COL3 * ORDERS.COL2) = 12))]"));
+    assertThat(querySpecification.getWhere().toString(), equalTo("Optional[(((ORDERS.COL2 IS NULL) AND (ORDERS.COL3 IS NOT NULL)) OR ((ORDERS.COL3 * ORDERS.COL2) = 12))]"));
   }
 
   @Test

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
@@ -1,0 +1,620 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.parser.rewrite;
+
+import io.confluent.ksql.function.TestFunctionRegistry;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.List;
+
+import io.confluent.ksql.ddl.DdlConfig;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.parser.KsqlParser;
+import io.confluent.ksql.parser.tree.AliasedRelation;
+import io.confluent.ksql.parser.tree.ComparisonExpression;
+import io.confluent.ksql.parser.tree.CreateStream;
+import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
+import io.confluent.ksql.parser.tree.CreateTable;
+import io.confluent.ksql.parser.tree.InsertInto;
+import io.confluent.ksql.parser.tree.Join;
+import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.parser.tree.QuerySpecification;
+import io.confluent.ksql.parser.tree.SingleColumn;
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.parser.tree.Struct;
+import io.confluent.ksql.parser.tree.Type;
+import io.confluent.ksql.util.MetaStoreFixture;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.IsNot.not;
+
+public class StatementRewriterTest {
+
+  private static final KsqlParser KSQL_PARSER = new KsqlParser();
+
+  private MetaStore metaStore;
+
+  @Before
+  public void init() {
+
+    metaStore = MetaStoreFixture.getNewMetaStore(new TestFunctionRegistry());
+  }
+
+  @Test
+  public void testSimpleQuery() {
+    String simpleQuery = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
+    Statement statement = KSQL_PARSER.buildAst(simpleQuery, metaStore).get(0);
+
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testSimpleQuery fails", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    Assert.assertTrue("testSimpleQuery fails", querySpecification.getSelect().getSelectItems().size() == 3);
+    assertThat(querySpecification.getFrom(), not(nullValue()));
+    Assert.assertTrue("testSimpleQuery fails", querySpecification.getWhere().isPresent());
+    Assert.assertTrue("testSimpleQuery fails", querySpecification.getWhere().get() instanceof ComparisonExpression);
+    ComparisonExpression comparisonExpression = (ComparisonExpression)querySpecification.getWhere().get();
+    Assert.assertTrue("testSimpleQuery fails", comparisonExpression.getType().getValue().equalsIgnoreCase(">"));
+
+  }
+
+  @Test
+  public void testProjection() {
+    String queryStr = "SELECT col0, col2, col3 FROM test1;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testProjection fails", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    Assert.assertTrue("testProjection fails", querySpecification.getSelect().getSelectItems().size() == 3);
+    Assert.assertTrue("testProjection fails", querySpecification.getSelect().getSelectItems().get(0) instanceof SingleColumn);
+    SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
+    Assert.assertTrue("testProjection fails", column0.getAlias().get().equalsIgnoreCase("COL0"));
+    Assert.assertTrue("testProjection fails", column0.getExpression().toString().equalsIgnoreCase("TEST1.COL0"));
+  }
+
+  @Test
+  public void testProjectionWithArrayMap() {
+    String queryStr = "SELECT col0, col2, col3, col4[0], col5['key1'] FROM test1;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testProjectionWithArrayMap fails", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    Assert.assertTrue("testProjectionWithArrayMap fails", querySpecification.getSelect().getSelectItems()
+        .size() == 5);
+    Assert.assertTrue("testProjectionWithArrayMap fails", querySpecification.getSelect().getSelectItems().get(0) instanceof SingleColumn);
+    SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
+    Assert.assertTrue("testProjectionWithArrayMap fails", column0.getAlias().get().equalsIgnoreCase("COL0"));
+    Assert.assertTrue("testProjectionWithArrayMap fails", column0.getExpression().toString().equalsIgnoreCase("TEST1.COL0"));
+
+    SingleColumn column3 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(3);
+    SingleColumn column4 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(4);
+    Assert.assertTrue("testProjectionWithArrayMap fails", column3.getExpression().toString()
+        .equalsIgnoreCase("TEST1.COL4[0]"));
+    Assert.assertTrue("testProjectionWithArrayMap fails", column4.getExpression().toString()
+        .equalsIgnoreCase("TEST1.COL5['key1']"));
+  }
+
+  @Test
+  public void testProjectFilter() {
+    String queryStr = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testProjectFilter fails", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+
+    Assert.assertTrue("testProjectFilter fails", querySpecification.getWhere().get() instanceof ComparisonExpression);
+    ComparisonExpression comparisonExpression = (ComparisonExpression)querySpecification.getWhere().get();
+    Assert.assertTrue("testProjectFilter fails", comparisonExpression.toString().equalsIgnoreCase("(TEST1.COL0 > 100)"));
+    Assert.assertTrue("testProjectFilter fails", querySpecification.getSelect().getSelectItems().size() == 3);
+
+  }
+
+  @Test
+  public void testBinaryExpression() {
+    String queryStr = "SELECT col0+10, col2, col3-col1 FROM test1;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testBinaryExpression fails", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
+    Assert.assertTrue("testBinaryExpression fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
+    Assert.assertTrue("testBinaryExpression fails", column0.getExpression().toString().equalsIgnoreCase("(TEST1.COL0 + 10)"));
+  }
+
+  @Test
+  public void testBooleanExpression() {
+    String queryStr = "SELECT col0 = 10, col2, col3 > col1 FROM test1;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testProjection fails", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
+    Assert.assertTrue("testBooleanExpression fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
+    Assert.assertTrue("testBooleanExpression fails", column0.getExpression().toString().equalsIgnoreCase("(TEST1.COL0 = 10)"));
+  }
+
+  @Test
+  public void testLiterals() {
+    String queryStr = "SELECT 10, col2, 'test', 2.5, true, -5 FROM test1;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testLiterals fails", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
+    Assert.assertTrue("testLiterals fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
+    Assert.assertTrue("testLiterals fails", column0.getExpression().toString().equalsIgnoreCase("10"));
+
+    SingleColumn column1 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(1);
+    Assert.assertTrue("testLiterals fails", column1.getAlias().get().equalsIgnoreCase("COL2"));
+    Assert.assertTrue("testLiterals fails", column1.getExpression().toString().equalsIgnoreCase("TEST1.COL2"));
+
+    SingleColumn column2 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(2);
+    Assert.assertTrue("testLiterals fails", column2.getAlias().get().equalsIgnoreCase("KSQL_COL_2"));
+    Assert.assertTrue("testLiterals fails", column2.getExpression().toString().equalsIgnoreCase("'test'"));
+
+    SingleColumn column3 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(3);
+    Assert.assertTrue("testLiterals fails", column3.getAlias().get().equalsIgnoreCase("KSQL_COL_3"));
+    Assert.assertTrue("testLiterals fails", column3.getExpression().toString().equalsIgnoreCase("2.5"));
+
+    SingleColumn column4 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(4);
+    Assert.assertTrue("testLiterals fails", column4.getAlias().get().equalsIgnoreCase("KSQL_COL_4"));
+    Assert.assertTrue("testLiterals fails", column4.getExpression().toString().equalsIgnoreCase("true"));
+
+    SingleColumn column5 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(5);
+    Assert.assertTrue("testLiterals fails", column5.getAlias().get().equalsIgnoreCase("KSQL_COL_5"));
+    Assert.assertTrue("testLiterals fails", column5.getExpression().toString().equalsIgnoreCase("-5"));
+  }
+
+  @Test
+  public void testBooleanLogicalExpression() {
+    String
+        queryStr =
+        "SELECT 10, col2, 'test', 2.5, true, -5 FROM test1 WHERE col1 = 10 AND col2 LIKE 'val' OR col4 > 2.6 ;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testProjection fails", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
+    Assert.assertTrue("testProjection fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
+    Assert.assertTrue("testProjection fails", column0.getExpression().toString().equalsIgnoreCase("10"));
+
+    SingleColumn column1 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(1);
+    Assert.assertTrue("testProjection fails", column1.getAlias().get().equalsIgnoreCase("COL2"));
+    Assert.assertTrue("testProjection fails", column1.getExpression().toString().equalsIgnoreCase("TEST1.COL2"));
+
+    SingleColumn column2 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(2);
+    Assert.assertTrue("testProjection fails", column2.getAlias().get().equalsIgnoreCase("KSQL_COL_2"));
+    Assert.assertTrue("testProjection fails", column2.getExpression().toString().equalsIgnoreCase("'test'"));
+
+  }
+
+  @Test
+  public void testSimpleLeftJoin() {
+    String
+        queryStr =
+        "SELECT t1.col1, t2.col1, t2.col4, col5, t2.col2 FROM test1 t1 LEFT JOIN test2 t2 ON "
+            + "t1.col1 = t2.col1;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testSimpleLeftJoin fails", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    Assert.assertTrue("testSimpleLeftJoin fails", querySpecification.getFrom() instanceof Join);
+    Join join = (Join) querySpecification.getFrom();
+    Assert.assertTrue("testSimpleLeftJoin fails", join.getType().toString().equalsIgnoreCase("LEFT"));
+
+    Assert.assertTrue("testSimpleLeftJoin fails", ((AliasedRelation)join.getLeft()).getAlias().equalsIgnoreCase("T1"));
+    Assert.assertTrue("testSimpleLeftJoin fails", ((AliasedRelation)join.getRight()).getAlias().equalsIgnoreCase("T2"));
+
+  }
+
+  @Test
+  public void testLeftJoinWithFilter() {
+    String
+        queryStr =
+        "SELECT t1.col1, t2.col1, t2.col4, t2.col2 FROM test1 t1 LEFT JOIN test2 t2 ON t1.col1 = "
+            + "t2.col1 WHERE t2.col2 = 'test';";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testLeftJoinWithFilter fails", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    Assert.assertTrue("testLeftJoinWithFilter fails", querySpecification.getFrom() instanceof Join);
+    Join join = (Join) querySpecification.getFrom();
+    Assert.assertTrue("testLeftJoinWithFilter fails", join.getType().toString().equalsIgnoreCase("LEFT"));
+
+    Assert.assertTrue("testLeftJoinWithFilter fails", ((AliasedRelation)join.getLeft()).getAlias().equalsIgnoreCase("T1"));
+    Assert.assertTrue("testLeftJoinWithFilter fails", ((AliasedRelation)join.getRight()).getAlias().equalsIgnoreCase("T2"));
+
+    Assert.assertTrue("testLeftJoinWithFilter fails", querySpecification.getWhere().get().toString().equalsIgnoreCase("(T2.COL2 = 'test')"));
+  }
+
+  @Test
+  public void testSelectAll() {
+    String queryStr = "SELECT * FROM test1 t1;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testSelectAll fails", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    Assert.assertTrue("testSelectAll fails", querySpecification.getSelect().getSelectItems()
+        .size() == 8);
+  }
+
+  @Test
+  public void testSelectAllJoin() {
+    String
+        queryStr =
+        "SELECT * FROM test1 t1 LEFT JOIN test2 t2 ON t1.col1 = t2.col1 WHERE t2.col2 = 'test';";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testLeftJoinWithFilter fails", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    Assert.assertTrue("testSelectAllJoin fails", querySpecification.getFrom() instanceof Join);
+    Join join = (Join) querySpecification.getFrom();
+    Assert.assertTrue("testSelectAllJoin fails", querySpecification.getSelect().getSelectItems
+        ().size() == 15);
+    Assert.assertTrue("testLeftJoinWithFilter fails", ((AliasedRelation)join.getLeft()).getAlias().equalsIgnoreCase("T1"));
+    Assert.assertTrue("testLeftJoinWithFilter fails", ((AliasedRelation)join.getRight()).getAlias().equalsIgnoreCase("T2"));
+  }
+
+  @Test
+  public void testUDF() {
+    String queryStr = "SELECT lcase(col1), concat(col2,'hello'), floor(abs(col3)) FROM test1 t1;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSimpleQuery fails", rewrittenStatement instanceof Query);
+
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testSelectAll fails", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+
+    SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
+    Assert.assertTrue("testProjection fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
+    Assert.assertTrue("testProjection fails", column0.getExpression().toString().equalsIgnoreCase("LCASE(T1.COL1)"));
+
+    SingleColumn column1 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(1);
+    Assert.assertTrue("testProjection fails", column1.getAlias().get().equalsIgnoreCase("KSQL_COL_1"));
+    Assert.assertTrue("testProjection fails", column1.getExpression().toString().equalsIgnoreCase("CONCAT(T1.COL2, 'hello')"));
+
+    SingleColumn column2 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(2);
+    Assert.assertTrue("testProjection fails", column2.getAlias().get().equalsIgnoreCase("KSQL_COL_2"));
+    Assert.assertTrue("testProjection fails", column2.getExpression().toString().equalsIgnoreCase("FLOOR(ABS(T1.COL3))"));
+  }
+
+  @Test
+  public void testCreateStreamWithTopic() {
+    String
+        queryStr =
+        "CREATE STREAM orders (ordertime bigint, orderid varchar, itemid varchar, orderunits "
+            + "double) WITH (registered_topic = 'orders_topic' , key='ordertime');";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testCreateStream failed.", rewrittenStatement instanceof CreateStream);
+    CreateStream createStream = (CreateStream)rewrittenStatement;
+    Assert.assertTrue("testCreateStream failed.", createStream.getName().toString().equalsIgnoreCase("ORDERS"));
+    Assert.assertTrue("testCreateStream failed.", createStream.getElements().size() == 4);
+    Assert.assertTrue("testCreateStream failed.", createStream.getElements().get(0).getName().toString().equalsIgnoreCase("ordertime"));
+    Assert.assertTrue("testCreateStream failed.", createStream.getProperties().get(DdlConfig.TOPIC_NAME_PROPERTY).toString().equalsIgnoreCase("'orders_topic'"));
+  }
+
+  @Test
+  public void testCreateStreamWithTopicWithStruct() throws Exception {
+    String
+        queryStr =
+        "CREATE STREAM orders (ordertime bigint, orderid varchar, itemid varchar, orderunits "
+            + "double, arraycol array<double>, mapcol map<varchar, double>, "
+            + "order_address STRUCT < number VARCHAR, street VARCHAR, zip INTEGER, city "
+            + "VARCHAR, state VARCHAR >) WITH (registered_topic = 'orders_topic' , key='ordertime');";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testCreateStream failed.", rewrittenStatement instanceof CreateStream);
+    CreateStream createStream = (CreateStream)rewrittenStatement;
+    assertThat(createStream.getName().toString().toUpperCase(), equalTo("ORDERS"));
+    assertThat(createStream.getElements().size(), equalTo(7));
+    assertThat(createStream.getElements().get(0).getName().toString().toLowerCase(), equalTo("ordertime"));
+    assertThat(createStream.getElements().get(6).getType().getKsqlType(), equalTo(Type.KsqlType.STRUCT));
+    Struct struct = (Struct) createStream.getElements().get(6).getType();
+    assertThat(struct.getItems().size(), equalTo(5));
+    assertThat(struct.getItems().get(0).getRight().getKsqlType(), equalTo(Type.KsqlType.STRING));
+    assertThat(createStream.getProperties().get(DdlConfig.TOPIC_NAME_PROPERTY).toString().toLowerCase(),
+        equalTo("'orders_topic'"));
+  }
+
+  @Test
+  public void testCreateStream() throws Exception {
+    String
+        queryStr =
+        "CREATE STREAM orders (ordertime bigint, orderid varchar, itemid varchar, orderunits "
+            + "double) WITH (value_format = 'avro', "
+            + "avroschemafile='/Users/hojjat/avro_order_schema.avro',kafka_topic='orders_topic');";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testCreateStream failed.", rewrittenStatement instanceof CreateStream);
+    CreateStream createStream = (CreateStream)rewrittenStatement;
+
+    Assert.assertTrue("testCreateStream failed.", createStream.getName().toString().equalsIgnoreCase("ORDERS"));
+    Assert.assertTrue("testCreateStream failed.", createStream.getElements().size() == 4);
+    Assert.assertTrue("testCreateStream failed.", createStream.getElements().get(0).getName().toString().equalsIgnoreCase("ordertime"));
+    Assert.assertTrue("testCreateStream failed.", createStream.getProperties().get(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY).toString().equalsIgnoreCase("'orders_topic'"));
+    Assert.assertTrue("testCreateStream failed.", createStream.getProperties().get(DdlConfig
+        .VALUE_FORMAT_PROPERTY).toString().equalsIgnoreCase("'avro'"));
+    Assert.assertTrue("testCreateStream failed.", createStream.getProperties().get(DdlConfig.AVRO_SCHEMA_FILE).toString().equalsIgnoreCase("'/Users/hojjat/avro_order_schema.avro'"));
+  }
+
+  @Test
+  public void testCreateTableWithTopic() {
+    String
+        queryStr =
+        "CREATE TABLE users (usertime bigint, userid varchar, regionid varchar, gender varchar) WITH (registered_topic = 'users_topic', key='userid', statestore='user_statestore');";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+    Assert.assertTrue("testRegisterTopic failed.", rewrittenStatement instanceof CreateTable);
+    CreateTable createTable = (CreateTable)rewrittenStatement;
+    Assert.assertTrue("testCreateTable failed.", createTable.getName().toString().equalsIgnoreCase("USERS"));
+    Assert.assertTrue("testCreateTable failed.", createTable.getElements().size() == 4);
+    Assert.assertTrue("testCreateTable failed.", createTable.getElements().get(0).getName().toString().equalsIgnoreCase("usertime"));
+    Assert.assertTrue("testCreateTable failed.", createTable.getProperties().get(DdlConfig.TOPIC_NAME_PROPERTY).toString().equalsIgnoreCase("'users_topic'"));
+  }
+
+  @Test
+  public void testCreateTable() {
+    String
+        queryStr =
+        "CREATE TABLE users (usertime bigint, userid varchar, regionid varchar, gender varchar) "
+            + "WITH (kafka_topic = 'users_topic', value_format='json', key = 'userid');";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+    Assert.assertTrue("testRegisterTopic failed.", rewrittenStatement instanceof CreateTable);
+    CreateTable createTable = (CreateTable)rewrittenStatement;
+    Assert.assertTrue("testCreateTable failed.", createTable.getName().toString().equalsIgnoreCase("USERS"));
+    Assert.assertTrue("testCreateTable failed.", createTable.getElements().size() == 4);
+    Assert.assertTrue("testCreateTable failed.", createTable.getElements().get(0).getName().toString().equalsIgnoreCase("usertime"));
+    Assert.assertTrue("testCreateTable failed.", createTable.getProperties().get(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY)
+        .toString().equalsIgnoreCase("'users_topic'"));
+    Assert.assertTrue("testCreateTable failed.", createTable.getProperties().get(DdlConfig.VALUE_FORMAT_PROPERTY)
+        .toString().equalsIgnoreCase("'json'"));
+  }
+
+  @Test
+  public void testCreateStreamAsSelect() {
+
+    String
+        queryStr =
+        "CREATE STREAM bigorders_json WITH (value_format = 'json', "
+            + "kafka_topic='bigorders_topic') AS SELECT * FROM orders WHERE orderunits > 5 ;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testCreateStreamAsSelect failed.", rewrittenStatement instanceof CreateStreamAsSelect);
+    CreateStreamAsSelect createStreamAsSelect = (CreateStreamAsSelect)rewrittenStatement;
+    Assert.assertTrue("testCreateTable failed.", createStreamAsSelect.getName().toString().equalsIgnoreCase("bigorders_json"));
+    Assert.assertTrue("testCreateTable failed.", createStreamAsSelect.getQuery().getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification) createStreamAsSelect.getQuery().getQueryBody();
+    Assert.assertTrue("testCreateTable failed.", querySpecification.getSelect().getSelectItems().size() == 4);
+    Assert.assertTrue("testCreateTable failed.", querySpecification.getWhere().get().toString().equalsIgnoreCase("(ORDERS.ORDERUNITS > 5)"));
+    Assert.assertTrue("testCreateTable failed.", ((AliasedRelation)querySpecification.getFrom()).getAlias().equalsIgnoreCase("ORDERS"));
+  }
+
+
+  @Test
+  public void testSelectTumblingWindow() {
+
+    String
+        queryStr =
+        "select itemid, sum(orderunits) from orders window TUMBLING ( size 30 second) where orderunits > 5 group by itemid;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSelectTumblingWindow failed.", rewrittenStatement instanceof Query);
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testSelectTumblingWindow failed.", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification) query.getQueryBody();
+    Assert.assertTrue("testCreateTable failed.", querySpecification.getSelect().getSelectItems
+        ().size() == 2);
+    Assert.assertTrue("testSelectTumblingWindow failed.", querySpecification.getWhere().get().toString().equalsIgnoreCase("(ORDERS.ORDERUNITS > 5)"));
+    Assert.assertTrue("testSelectTumblingWindow failed.", ((AliasedRelation)querySpecification.getFrom()).getAlias().equalsIgnoreCase("ORDERS"));
+    Assert.assertTrue("testSelectTumblingWindow failed.", querySpecification
+        .getWindowExpression().isPresent());
+    Assert.assertTrue("testSelectTumblingWindow failed.", querySpecification
+        .getWindowExpression().get().toString().equalsIgnoreCase(" WINDOW STREAMWINDOW  TUMBLING ( SIZE 30 SECONDS ) "));
+  }
+
+  @Test
+  public void testSelectHoppingWindow() {
+
+    String
+        queryStr =
+        "select itemid, sum(orderunits) from orders window HOPPING ( size 30 second, advance by 5"
+            + " seconds) "
+            + "where "
+            + "orderunits"
+            + " > 5 group by itemid;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    assertThat(rewrittenStatement, instanceOf(Query.class));
+    Query query = (Query) rewrittenStatement;
+    assertThat(query.getQueryBody(), instanceOf(QuerySpecification.class));
+    QuerySpecification querySpecification = (QuerySpecification) query.getQueryBody();
+    assertThat(querySpecification.getSelect().getSelectItems().size(), equalTo(2));
+    assertThat(querySpecification.getWhere().get().toString(), equalTo("(ORDERS.ORDERUNITS > 5)"));
+    assertThat(((AliasedRelation)querySpecification.getFrom()).getAlias().toUpperCase(), equalTo("ORDERS"));
+    Assert.assertTrue("window expression isn't present", querySpecification
+        .getWindowExpression().isPresent());
+    assertThat(querySpecification.getWindowExpression().get().toString().toUpperCase(),
+        equalTo(" WINDOW STREAMWINDOW  HOPPING ( SIZE 30 SECONDS , ADVANCE BY 5 SECONDS ) "));
+  }
+
+  @Test
+  public void should() {
+    List<Statement> statements = KSQL_PARSER.buildAst("select * from orders;", metaStore);
+    System.out.println(statements);
+  }
+  @Test
+  public void testSelectSessionWindow() {
+
+    String
+        queryStr =
+        "select itemid, sum(orderunits) from orders window SESSION ( 30 second) where "
+            + "orderunits > 5 group by itemid;";
+    Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
+
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSelectSessionWindow failed.", rewrittenStatement instanceof Query);
+    Query query = (Query) rewrittenStatement;
+    Assert.assertTrue("testSelectSessionWindow failed.", query.getQueryBody() instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification) query.getQueryBody();
+    Assert.assertTrue("testCreateTable failed.", querySpecification.getSelect().getSelectItems
+        ().size() == 2);
+    Assert.assertTrue("testSelectSessionWindow failed.", querySpecification.getWhere().get().toString().equalsIgnoreCase("(ORDERS.ORDERUNITS > 5)"));
+    Assert.assertTrue("testSelectSessionWindow failed.", ((AliasedRelation)querySpecification.getFrom()).getAlias().equalsIgnoreCase("ORDERS"));
+    Assert.assertTrue("testSelectSessionWindow failed.", querySpecification
+        .getWindowExpression().isPresent());
+    Assert.assertTrue("testSelectSessionWindow failed.", querySpecification
+        .getWindowExpression().get().toString().equalsIgnoreCase(" WINDOW STREAMWINDOW  SESSION "
+            + "( 30 SECONDS ) "));
+  }
+
+
+  @Test
+  public void testSelectSinkProperties() {
+    String simpleQuery = "create stream s1 with (timestamp='orderid', partitions = 3) as select "
+        + "col1, col2"
+        + " from orders where col2 is null and col3 is not null or (col3*col2 = "
+        + "12);";
+    Statement statement = KSQL_PARSER.buildAst(simpleQuery, metaStore).get(0);
+
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    Assert.assertTrue("testSelectTumblingWindow failed.", rewrittenStatement instanceof CreateStreamAsSelect);
+    CreateStreamAsSelect createStreamAsSelect = (CreateStreamAsSelect) rewrittenStatement;
+    Assert.assertTrue("testSelectTumblingWindow failed.", createStreamAsSelect.getQuery().getQueryBody()
+        instanceof QuerySpecification);
+    QuerySpecification querySpecification = (QuerySpecification)
+        createStreamAsSelect.getQuery().getQueryBody();
+    Assert.assertTrue(querySpecification.getWhere().toString().equalsIgnoreCase("Optional[(((ORDERS.COL2 IS NULL) AND (ORDERS.COL3 IS NOT NULL)) OR ((ORDERS.COL3 * ORDERS.COL2) = 12))]"));
+  }
+
+  @Test
+  public void testInsertInto() {
+    String insertIntoString = "INSERT INTO test2 SELECT col0, col2, col3 FROM test1 WHERE col0 > "
+        + "100;";
+    Statement statement = KSQL_PARSER.buildAst(insertIntoString, metaStore).get(0);
+
+    StatementRewriter statementRewriter = new StatementRewriter();
+    Statement rewrittenStatement = (Statement) statementRewriter.process(statement, null);
+
+    assertThat(rewrittenStatement, instanceOf(InsertInto.class));
+    InsertInto insertInto = (InsertInto) rewrittenStatement;
+    assertThat(insertInto.getTarget().toString(), equalTo("TEST2"));
+    Query query = insertInto.getQuery();
+    assertThat(query.getQueryBody(), instanceOf(QuerySpecification.class));
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    assertThat( querySpecification.getSelect().getSelectItems().size(), equalTo(3));
+    assertThat(querySpecification.getFrom(), not(nullValue()));
+    assertThat(querySpecification.getWhere().isPresent(), equalTo(true));
+    assertThat(querySpecification.getWhere().get(),  instanceOf(ComparisonExpression.class));
+    ComparisonExpression comparisonExpression = (ComparisonExpression)querySpecification.getWhere().get();
+    assertThat(comparisonExpression.getType().getValue(), equalTo(">"));
+
+  }
+
+}


### PR DESCRIPTION
This is a new feature to rewrite the queries using changing the AST. This will be used in supporting struct type.
We added a new visitor that visits an AST and creates a copy of it. To rewrite a query you can inherit from this visitor and override the methods that you need.
Some changes had to be made in the AstVistor and some nodes so we can create the full tree.