### PR TITLE
Changes in the AST node to support the struct fields correctly.

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -20,10 +20,10 @@
     <suppress files="(KafkaConsumerGroupClientImpl.java)" checks="ClassDataAbstractionCouplingCheck"/>
     <suppress files="(KsqlResource|KsqlRestApplication|StandaloneExecutor|KsqlRestClient).java" checks="ClassDataAbstractionCouplingCheck"/>
     <suppress files="Console.java" checks="ClassDataAbstractionCouplingCheck"/>
-    <suppress files="(DataGenProducer|DataGen|Generator|PhysicalPlanBuilder).java"
+    <suppress files="(DataGenProducer|DataGen|Generator|PhysicalPlanBuilder|StatementRewriter).java"
               checks="ClassDataAbstractionCouplingCheck"/>
     <suppress
-            files="(ExpressionTypeManager|KsqlResource|Console|KsqlEngine|PhysicalPlanBuilder|DropSourceCommand).java"
+            files="(ExpressionTypeManager|KsqlResource|Console|KsqlEngine|PhysicalPlanBuilder|DropSourceCommand|AstBuilder).java"
               checks="CyclomaticComplexityCheck"/>
 
     <!-- EXAMPLES! -->

--- a/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.util;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 import io.confluent.ksql.function.FunctionRegistry;
@@ -84,11 +85,37 @@ public class MetaStoreFixture {
     metaStore.putTopic(ksqlTopic2);
     metaStore.putSource(ksqlTable);
 
-    SchemaBuilder schemaBuilderOrders = SchemaBuilder.struct()
-        .field("ORDERTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-        .field("ORDERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-        .field("ITEMID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-        .field("ORDERUNITS", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA);
+
+    final Schema addressSchema = SchemaBuilder.struct()
+        .field("NUMBER", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("STREET", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("CITY", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("STATE", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("ZIPCODE", Schema.OPTIONAL_INT64_SCHEMA)
+        .optional().build();
+
+    final Schema categorySchema = SchemaBuilder.struct()
+        .field("ID", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("NAME", Schema.OPTIONAL_STRING_SCHEMA)
+        .optional().build();
+
+    final Schema itemInfoSchema = SchemaBuilder.struct()
+        .field("ITEMID", Schema.INT64_SCHEMA)
+        .field("NAME", Schema.STRING_SCHEMA)
+        .field("CATEGORY", categorySchema)
+        .optional().build();
+
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
+    final Schema schemaBuilderOrders = schemaBuilder
+        .field("ORDERTIME", Schema.INT64_SCHEMA)
+        .field("ORDERID", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("ITEMID", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("ITEMINFO", itemInfoSchema)
+        .field("ORDERUNITS", Schema.INT32_SCHEMA)
+        .field("ARRAYCOL",schemaBuilder.array(Schema.FLOAT64_SCHEMA).optional().build())
+        .field("MAPCOL", schemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA).optional().build())
+        .field("ADDRESS", addressSchema)
+        .build();
 
     KsqlTopic
         ksqlTopicOrders =

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -1129,11 +1129,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
   @Override
   public Node visitDereference(SqlBaseParser.DereferenceContext context) {
     String fieldName = getIdentifierText(context.identifier());
-    Expression baseExpression;
-    QualifiedName tableName = QualifiedName.of(
-        context.primaryExpression().getText().toUpperCase());
-    baseExpression = new QualifiedNameReference(
-        getLocation(context.primaryExpression()), tableName);
+    Expression baseExpression = (Expression) visit(context.base);
     DereferenceExpression dereferenceExpression =
         new DereferenceExpression(getLocation(context), baseExpression, fieldName);
     return dereferenceExpression;
@@ -1144,6 +1140,15 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
     String columnName = getIdentifierText(context.identifier());
     // If this is join.
     if (dataSourceExtractor.getJoinLeftSchema() != null) {
+      if (columnName.equalsIgnoreCase(dataSourceExtractor.getLeftAlias())
+          || columnName.equalsIgnoreCase(dataSourceExtractor.getLeftName())
+          || columnName.equalsIgnoreCase(dataSourceExtractor.getRightAlias())
+          || columnName.equalsIgnoreCase(dataSourceExtractor.getRightName())) {
+        return new QualifiedNameReference(
+            getLocation(context),
+            QualifiedName.of(columnName)
+        );
+      }
       if (dataSourceExtractor.getCommonFieldNames().contains(columnName)) {
         throw new KsqlException("Field " + columnName + " is ambiguous.");
       } else if (dataSourceExtractor.getLeftFieldNames().contains(columnName)) {
@@ -1164,12 +1169,20 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
         throw new InvalidColumnReferenceException("Field " + columnName + " is ambiguous.");
       }
     } else {
-      Expression baseExpression =
-          new QualifiedNameReference(
-              getLocation(context),
-              QualifiedName.of(dataSourceExtractor.getFromAlias())
-          );
-      return new DereferenceExpression(getLocation(context), baseExpression, columnName);
+      if (columnName.equalsIgnoreCase(dataSourceExtractor.getFromAlias())
+          || columnName.equalsIgnoreCase(dataSourceExtractor.getFromName())) {
+        return new QualifiedNameReference(
+            getLocation(context),
+            QualifiedName.of(columnName)
+        );
+      } else {
+        Expression baseExpression =
+            new QualifiedNameReference(
+                getLocation(context),
+                QualifiedName.of(dataSourceExtractor.getFromAlias())
+            );
+        return new DereferenceExpression(getLocation(context), baseExpression, columnName);
+      }
     }
   }
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
@@ -479,7 +479,7 @@ public class StatementRewriterTest {
     assertThat("testCreateTable failed.", createStreamAsSelect.getName().toString(), equalTo("BIGORDERS_JSON"));
     assertThat("testCreateTable failed.", createStreamAsSelect.getQuery().getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification) createStreamAsSelect.getQuery().getQueryBody();
-    assertThat("testCreateTable failed.", querySpecification.getSelect().getSelectItems().size() == 4);
+    assertThat("testCreateTable failed.", querySpecification.getSelect().getSelectItems().size() == 8);
     assertThat("testCreateTable failed.", querySpecification.getWhere().get().toString(), equalTo("(ORDERS.ORDERUNITS > 5)"));
     assertThat("testCreateTable failed.", ((AliasedRelation)querySpecification.getFrom()).getAlias(), equalTo("ORDERS"));
   }


### PR DESCRIPTION
This PR makes changes in our AST so we can handle dot notation to access nested fields in struct correctly.
Previously we assumed that we have only one dot, `stream/table name`.`column name`. How we will be able to have more than one dot in a dereferenced node.
This is based on the previous PR for Query rewrite.