### PR TITLE
Query rewrite with struct field fetcher function.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/structfieldextractor/FetchFieldFromStruct.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/structfieldextractor/FetchFieldFromStruct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Confluent Inc.
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ import io.confluent.ksql.function.udf.Kudf;
 
 public class FetchFieldFromStruct implements Kudf {
 
-  public static final String functionName = "FETCH_FIELD_FROM_STRUCT";
+  public static final String FUNCTION_NAME = "FETCH_FIELD_FROM_STRUCT";
 
   @Override
-  public Object evaluate(Object... args) {
+  public Object evaluate(final Object... args) {
     if (args.length != 2) {
       throw new KsqlFunctionException("Function FetchFieldFromStruct should have two arguments.");
     }
@@ -34,7 +34,7 @@ public class FetchFieldFromStruct implements Kudf {
       throw new KsqlFunctionException("Invalid data type. Function argument should be Struct type"
           + ".");
     }
-    Struct struct = (Struct) args[0];
+    final Struct struct = (Struct) args[0];
     return struct.get((String) args[1]);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/structfieldextractor/FetchFieldFromStruct.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/structfieldextractor/FetchFieldFromStruct.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.function.udf.structfieldextractor;
+
+import org.apache.kafka.connect.data.Struct;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Kudf;
+
+public class FetchFieldFromStruct implements Kudf {
+
+  public static final String functionName = "FETCH_FIELD_FROM_STRUCT";
+
+  @Override
+  public Object evaluate(Object... args) {
+    if (args.length != 2) {
+      throw new KsqlFunctionException("Function FetchFieldFromStruct should have two arguments.");
+    }
+    if (!(args[0] instanceof Struct)) {
+      throw new KsqlFunctionException("Invalid data type. Function argument should be Struct type"
+          + ".");
+    }
+    Struct struct = (Struct) args[0];
+    return struct.get((String) args[1]);
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/structfieldextractor/FetchFieldFromStructTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/structfieldextractor/FetchFieldFromStructTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.structfieldextractor;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.instanceOf;
+
+public class FetchFieldFromStructTest {
+
+  FetchFieldFromStruct fetchFieldFromStruct = new FetchFieldFromStruct();
+
+  final private Schema addressSchema = SchemaBuilder.struct()
+      .field("NUMBER", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("STREET", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("CITY", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("STATE", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("ZIPCODE", Schema.OPTIONAL_INT64_SCHEMA)
+      .optional().build();
+
+  private Struct getStruct() {
+    Struct address = new Struct(addressSchema);
+    address.put("NUMBER", 101L);
+    address.put("STREET", "University Ave.");
+    address.put("CITY", "Palo Alto");
+    address.put("STATE", "CA");
+    address.put("ZIPCODE", 94301L);
+
+    return address;
+  }
+
+  @Test
+  public void shouldReturnCorrectField() {
+    Object result = fetchFieldFromStruct.evaluate(getStruct(), "NUMBER");
+    assertThat(result, instanceOf(Long.class));
+    assertThat(result, equalTo(101L));
+  }
+
+  @Test
+  public void shouldFailIfFirstArgIsNotStruct() {
+    try {
+      Object result = fetchFieldFromStruct.evaluate(getStruct().get("STATE"), "STATE");
+      Assert.fail();
+    } catch (KsqlFunctionException e) {
+      assertThat(e.getMessage(), equalTo("Invalid data type. Function argument should be Struct type."));
+    }
+  }
+}

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriteForStruct.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriteForStruct.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.parser.rewrite;
+
+import org.apache.kafka.connect.data.Field;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.StructuredDataSource;
+import io.confluent.ksql.parser.tree.DereferenceExpression;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.FunctionCall;
+import io.confluent.ksql.parser.tree.Node;
+import io.confluent.ksql.parser.tree.QualifiedName;
+import io.confluent.ksql.parser.tree.QualifiedNameReference;
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.parser.tree.StringLiteral;
+import io.confluent.ksql.util.DataSourceExtractor;
+
+public class StatementRewriteForStruct {
+
+  private Statement statement;
+  private MetaStore metaStore;
+  private DataSourceExtractor dataSourceExtractor;
+
+  public StatementRewriteForStruct(
+      final Statement statement,
+      final MetaStore metaStore,
+      final DataSourceExtractor dataSourceExtractor
+  ) {
+    this.statement = statement;
+    this.metaStore = metaStore;
+    this.dataSourceExtractor = dataSourceExtractor;
+  }
+
+  public Statement rewriteForStruct() {
+    RewriteWithStructFieldExtractors statementRewriter = new RewriteWithStructFieldExtractors();
+    return (Statement) statementRewriter.process(statement, null);
+  }
+
+
+  private class RewriteWithStructFieldExtractors extends StatementRewriter {
+
+    @Override
+    protected Node visitDereferenceExpression(
+        final DereferenceExpression node,
+        final Object context
+    ) {
+      return createFetchFunctionNodeIfNeeded(node, context);
+    }
+
+    private Expression createFetchFunctionNodeIfNeeded(
+        final DereferenceExpression dereferenceExpression,
+        final Object context
+    ) {
+      if (dereferenceExpression.getBase() instanceof QualifiedNameReference) {
+        String sourceName = dereferenceExpression.getBase().toString();
+        if (dataSourceExtractor.getAliasToNameMap().containsKey(sourceName)) {
+          sourceName = dataSourceExtractor.getAliasToNameMap().get(sourceName);
+        }
+        StructuredDataSource structuredDataSource = metaStore.getSource(sourceName);
+        Field field = structuredDataSource.getSchema().field(
+            dereferenceExpression.getFieldName().toUpperCase()
+        );
+        DereferenceExpression newDereferenceExpression;
+        if (dereferenceExpression.getLocation().isPresent()) {
+          newDereferenceExpression = new DereferenceExpression(
+              dereferenceExpression.getLocation().get(),
+              (Expression) process(dereferenceExpression.getBase(), context),
+              dereferenceExpression.getFieldName()
+          );
+        } else {
+          newDereferenceExpression = new DereferenceExpression(
+              (Expression) process(dereferenceExpression.getBase(), context),
+              dereferenceExpression.getFieldName()
+          );
+        }
+
+        return newDereferenceExpression;
+      }
+      List<Expression> argList = new ArrayList<>();
+      Expression createFunctionResult = createFetchFunctionNodeIfNeeded(
+          (DereferenceExpression) dereferenceExpression.getBase(), context);
+
+      argList.add(createFunctionResult);
+      String fieldName = dereferenceExpression.getFieldName();
+      argList.add(new StringLiteral(fieldName));
+      return new FunctionCall(QualifiedName.of("FETCH_FIELD_FROM_STRUCT"), argList);
+    }
+  }
+
+}

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriteForStructTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriteForStructTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Confluent Inc.
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ public class StatementRewriteForStructTest {
 
   @Before
   public void init() {
-
     metaStore = MetaStoreFixture.getNewMetaStore(new TestFunctionRegistry());
   }
 
@@ -57,7 +56,6 @@ public class StatementRewriteForStructTest {
 
     StatementRewriteForStruct statementRewriteForStruct = new StatementRewriteForStruct(
         statement,
-        metaStore,
         dataSourceExtractor
     );
     Statement rewrittenStatement = statementRewriteForStruct.rewriteForStruct();

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriteForStructTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriteForStructTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.parser.rewrite;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+import io.confluent.ksql.function.TestFunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.parser.KsqlParser;
+import io.confluent.ksql.parser.SqlBaseParser.SingleStatementContext;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.FunctionCall;
+import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.parser.tree.QuerySpecification;
+import io.confluent.ksql.parser.tree.SingleColumn;
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.util.DataSourceExtractor;
+import io.confluent.ksql.util.MetaStoreFixture;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StatementRewriteForStructTest {
+
+  private static final KsqlParser KSQL_PARSER = new KsqlParser();
+
+  private MetaStore metaStore;
+
+  @Before
+  public void init() {
+
+    metaStore = MetaStoreFixture.getNewMetaStore(new TestFunctionRegistry());
+  }
+
+  @Test
+  public void shouldCreateCorrectFunctionCallExpression() {
+    String simpleQuery = "SELECT iteminfo.category.name, address.state FROM orders;";
+    Statement statement = KSQL_PARSER.buildAst(simpleQuery, metaStore).get(0);
+    SingleStatementContext singleStatementContext = KSQL_PARSER.getStatements(simpleQuery).get(0);
+    DataSourceExtractor dataSourceExtractor = new DataSourceExtractor(metaStore);
+    dataSourceExtractor.extractDataSources(singleStatementContext);
+
+    StatementRewriteForStruct statementRewriteForStruct = new StatementRewriteForStruct(
+        statement,
+        metaStore,
+        dataSourceExtractor
+    );
+    Statement rewrittenStatement = statementRewriteForStruct.rewriteForStruct();
+
+    assertThat( rewrittenStatement, instanceOf(Query.class));
+    Query query = (Query) rewrittenStatement;
+    assertThat( query.getQueryBody(), instanceOf(QuerySpecification.class));
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    assertThat( querySpecification.getSelect().getSelectItems().size(), equalTo(2));
+    Expression col0 = ((SingleColumn) querySpecification.getSelect().getSelectItems().get(0)).getExpression();
+    Expression col1 = ((SingleColumn) querySpecification.getSelect().getSelectItems().get(1)).getExpression();
+
+    assertThat(col0, instanceOf(FunctionCall.class));
+    assertThat(col1, instanceOf(FunctionCall.class));
+
+    assertThat(col0.toString(), equalTo("FETCH_FIELD_FROM_STRUCT(FETCH_FIELD_FROM_STRUCT(ORDERS.ITEMINFO, 'CATEGORY'), 'NAME')"));
+    assertThat(col1.toString(), equalTo("FETCH_FIELD_FROM_STRUCT(ORDERS.ADDRESS, 'STATE')"));
+
+  }
+
+}


### PR DESCRIPTION
This PR adds Query rewrite for handling struct type. The dot notation is replaced with function calls.
Anytime we create an AST we then check if it's a Query and if it is we rewrite it so any dot notation is replaced with function calls.